### PR TITLE
Show cuts from thorns on rolls

### DIFF
--- a/src/module/dice/rolls.mjs
+++ b/src/module/dice/rolls.mjs
@@ -14,7 +14,10 @@ export default class GrimwildRoll extends Roll {
 			dice: this.dice[0].results,
 			thorns: this.dice[1].results,
 			crit: false,
-			success: 0
+			success: 0,
+			rawSuccess: 0,
+			rawResult: "",
+			isCut: false
 		};
 
 		const sixes = chatData.dice.filter((die) => die.result === 6);
@@ -38,41 +41,57 @@ export default class GrimwildRoll extends Roll {
 			chatData.success = 0;
 		}
 
+		chatData.rawSuccess = chatData.success;
+
 		// Handle cuts.
 		if (!chatData.crit && cuts.length > 0) {
 			chatData.success -= cuts.length;
 		}
 
 		// Constraints.
-		if (chatData.success < -1) {
-			chatData.success = -1;
-		}
-		else if (chatData.success > 3) {
-			chatData.success = 3;
-		}
+		chatData.success = setSuccessConstraint(chatData.success);
+		chatData.rawSuccess = setSuccessConstraint(chatData.rawSuccess);
 
 		// Handle messages.
-		switch (chatData.success) {
-			case 3:
-				chatData.result = "crit";
-				break;
-			case 2:
-				chatData.result = "perfect";
-				break;
-			case 1:
-				chatData.result = "messy";
-				break;
-			case 0:
-				chatData.result = "grim";
-				break;
-			case -1:
-				chatData.result = "disaster";
-				break;
-
-			default:
-				break;
-		}
+		chatData.result = successToResult(chatData.success);
+		chatData.rawResult = successToResult(chatData.rawSuccess);
+		chatData.isCut = chatData.success !== chatData.rawSuccess;
 
 		return renderTemplate(template, chatData);
+	}
+}
+
+/**
+ *
+ * @param success
+ */
+function setSuccessConstraint(success) {
+	if (success < -1) {
+		success = -1;
+	}
+	else if (success > 3) {
+		success = 3;
+	}
+	return success;
+}
+
+/**
+ *
+ * @param success
+ */
+function successToResult(success) {
+	switch (success) {
+		case 3:
+			return "crit";
+		case 2:
+			return "perfect";
+		case 1:
+			return "messy";
+		case 0:
+			return "grim";
+		case -1:
+			return "disaster";
+		default:
+			return "";
 	}
 }

--- a/src/templates/chat/roll-action.hbs
+++ b/src/templates/chat/roll-action.hbs
@@ -1,5 +1,8 @@
 <section class="grimwild-chat grimwild-roll {{result}}">
-  <h2>{{localize (concat "GRIMWILD.Dice.results." result)}}</h2>
+  <h2>{{#if isCut }}
+    {{localize (concat "GRIMWILD.Dice.results." rawResult)}} &#8594; 
+    {{/if}}
+    {{localize (concat "GRIMWILD.Dice.results." result)}}</h2>
   <em>{{stat}}</em>
   <div class="dice-tooltip expanded">
     <section class="tooltip-part">


### PR DESCRIPTION
This commit simply adds the calculation of if a roll was cut by a thorn and if so to show the original result and the cut result in the chat message to emphasize the roll of the thorns.

![Screenshot 2025-01-15 at 8 49 02 AM](https://github.com/user-attachments/assets/90897636-cd7a-4f83-a4c5-880f3d215285)
