### PR TITLE
Add basic stat roll dialog

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -95,6 +95,8 @@ GRIMWILD:
     Temporary: Temporary Effects
     Passive: Passive Effects
     Inactive: Inactive Effects
+  Dialog:
+    Roll: Roll
 TYPES:
   Actor:
     character: Character

--- a/src/module/data/actor-character.mjs
+++ b/src/module/data/actor-character.mjs
@@ -85,7 +85,26 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 		const rollData = this.getRollData();
 
 		if (options?.stat && rollData?.stats?.[options.stat]) {
-			const formula = `{(@stats.${options.stat})d6kh, (@thorns)d8}`;
+
+			const content = await renderTemplate('systems/grimwild/templates/dialog/stat-roll.hbs', {
+				diceDefault: rollData?.stats?.[options.stat],
+				thornsDefault: rollData?.thorns
+			});
+			const rollDialog = await foundry.applications.api.DialogV2.wait({
+				window: { title: "Grimwild Roll" },
+				content,
+				modal: true,
+				buttons: [
+				{
+				  label: "Roll",
+				  action: "roll",
+				  callback: (event, button, dialog) => {return {dice: button.form.elements.dice.value, thorns: button.form.elements.thorns.value}}
+				},
+				]
+			  });
+			  rollData.thorns = rollDialog.thorns;
+			  rollData.statDice = rollDialog.dice;
+			  const formula = `{(@statDice)d6kh, (@thorns)d8}`;
 			const roll = new grimwild.roll(formula, rollData);
 
 			await roll.toMessage({

--- a/src/module/data/actor-character.mjs
+++ b/src/module/data/actor-character.mjs
@@ -85,8 +85,7 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 		const rollData = this.getRollData();
 
 		if (options?.stat && rollData?.stats?.[options.stat]) {
-
-			const content = await renderTemplate('systems/grimwild/templates/dialog/stat-roll.hbs', {
+			const content = await renderTemplate("systems/grimwild/templates/dialog/stat-roll.hbs", {
 				diceDefault: rollData?.stats?.[options.stat],
 				thornsDefault: rollData?.thorns
 			});
@@ -95,16 +94,18 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 				content,
 				modal: true,
 				buttons: [
-				{
-				  label: "Roll",
-				  action: "roll",
-				  callback: (event, button, dialog) => {return {dice: button.form.elements.dice.value, thorns: button.form.elements.thorns.value}}
-				},
+					{
+						label: game.i18n.localize("GRIMWILD.Dialog.Roll"),
+						action: "roll",
+						callback: (event, button, dialog) => {
+							return { dice: button.form.elements.dice.value, thorns: button.form.elements.thorns.value };
+						}
+					}
 				]
-			  });
-			  rollData.thorns = rollDialog.thorns;
-			  rollData.statDice = rollDialog.dice;
-			  const formula = `{(@statDice)d6kh, (@thorns)d8}`;
+			});
+			rollData.thorns = rollDialog.thorns;
+			rollData.statDice = rollDialog.dice;
+			const formula = "{(@statDice)d6kh, (@thorns)d8}";
 			const roll = new grimwild.roll(formula, rollData);
 
 			await roll.toMessage({

--- a/src/styles/components/_dialog.scss
+++ b/src/styles/components/_dialog.scss
@@ -1,0 +1,28 @@
+.grimwild-form-group {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+
+    label {
+        flex: 4;
+        text-align: left;
+        margin-right: 10px;
+        font-weight: bold;
+    }
+
+    input {
+        flex: 1;
+        padding: 10px;
+        font-size: 1rem;
+        border: 1px solid #ccc;;
+        border-radius: 4px;
+        text-align: right;
+
+        &:focus {
+            outline: none;
+            border-color: #007BFF;
+            box-shadow: 0 0 4px #ccc;;
+        }
+    }
+}

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -27,3 +27,7 @@
     @import 'components/dice';
   }
 }
+
+.dialog {
+  @import 'components/dialog';
+}

--- a/src/templates/dialog/stat-roll.hbs
+++ b/src/templates/dialog/stat-roll.hbs
@@ -1,0 +1,8 @@
+    <div class="grimwild-form-group">
+        <label for="dice">Dice:</label>
+        <input type="number" id="dice" name="dice" value="{{diceDefault}}" min="0">
+    </div>
+    <div class="grimwild-form-group">
+        <label for="thorns">Thorns:</label>
+        <input type="number" id="thorns" name="thorns" value="{{thornsDefault}}" min="0">
+    </div>


### PR DESCRIPTION
This commit adds an extremely simple roll dialog to adjust number of dice and thorns rolled.

Ideally in the future this gets abstracted for all rolls from sheets and options to it are added based on the roll (e.g. add mastery dice for fighters)