### PR TITLE
Add talent data model and sheets

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -142,6 +142,10 @@ GRIMWILD:
           label: Quantity
         weight:
           label: Weight
+    base:
+      FIELDS:
+        description:
+          label: Description
     Talent:
       FIELDS:
     Challenge:

--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -60,6 +60,11 @@ GRIMWILD:
     thorns: Thorns
     difficulty: Difficulty
     total: Total
+  Resources:
+    pools: Pools
+    points: Points
+    toggles: Toggles
+    text: Text
   SheetLabels:
     Actor: Grimwild Actor Sheet
     Item: Grimwild Item Sheet
@@ -148,6 +153,10 @@ GRIMWILD:
           label: Description
     Talent:
       FIELDS:
+        notes:
+          label: Notes
+        resources:
+          label: Resources
     Challenge:
       FIELDS:
         rollFormula:

--- a/src/module/data/item-talent.mjs
+++ b/src/module/data/item-talent.mjs
@@ -17,7 +17,7 @@ export default class GrimwildTalent extends GrimwildItemBase {
 		// Ex: Spell theorems
 		schema.notes = new fields.SchemaField({
 			label: new fields.StringField(optionalString),
-			description: new fields.StringField(optionalString),
+			description: new fields.HTMLField({ required: true, blank: true }),
 		});
 
 		schema.resources = new fields.SchemaField({

--- a/src/module/data/item-talent.mjs
+++ b/src/module/data/item-talent.mjs
@@ -31,6 +31,9 @@ export default class GrimwildTalent extends GrimwildItemBase {
 			points: new fields.ArrayField(new fields.SchemaField({
 				label: new fields.StringField(optionalString),
 				description: new fields.StringField(optionalString),
+				// Whether or not to show checkboxes or just a raw number field.
+				showSteps: new fields.BooleanField(),
+				// Track the actual value numerically.
 				value: new fields.NumberField({
 					...requiredInteger,
 					initial: 0,

--- a/src/module/data/item-talent.mjs
+++ b/src/module/data/item-talent.mjs
@@ -1,3 +1,4 @@
+import { DicePoolField } from "../helpers/schema.mjs";
 import GrimwildItemBase from "./base-item.mjs";
 
 export default class GrimwildTalent extends GrimwildItemBase {
@@ -5,4 +6,54 @@ export default class GrimwildTalent extends GrimwildItemBase {
 		"GRIMWILD.Item.base",
 		"GRIMWILD.Item.Talent"
 	];
+
+	static defineSchema() {
+		const fields = foundry.data.fields;
+		const requiredInteger = { required: true, nullable: false, integer: true };
+		const requiredString = { required: true, blank: true };
+		const optionalString = { required: false, blank: true };
+		const schema = super.defineSchema();
+
+		// Ex: Spell theorems
+		schema.notes = new fields.SchemaField({
+			label: new fields.StringField(optionalString),
+			description: new fields.StringField(optionalString),
+		});
+
+		schema.resources = new fields.SchemaField({
+			// Ex: Patron patience, cleric spells.
+			pools: new fields.ArrayField(new fields.SchemaField({
+				label: new fields.StringField(optionalString),
+				description: new fields.StringField(optionalString),
+				value: new DicePoolField(),
+			})),
+			// Ex: Spells, sorcerer essence.
+			points: new fields.ArrayField(new fields.SchemaField({
+				label: new fields.StringField(optionalString),
+				description: new fields.StringField(optionalString),
+				value: new fields.NumberField({
+					...requiredInteger,
+					initial: 0,
+					min: 0,
+				}),
+				max: new fields.NumberField({
+					min: 1,
+				}),
+			})),
+			// Ex: Push on various talents.
+			toggles: new fields.ArrayField(new fields.SchemaField({
+				label: new fields.StringField(optionalString),
+				description: new fields.StringField(optionalString),
+				value: new fields.BooleanField(),
+			})),
+			// Ex: ...maybe not needed? TBD on this one.
+			text: new fields.ArrayField(new fields.SchemaField({
+				label: new fields.StringField(optionalString),
+				description: new fields.StringField(optionalString),
+				value: new fields.StringField(optionalString),
+			})),
+		});
+
+		return schema;
+	}
 }

--- a/src/module/data/item-talent.mjs
+++ b/src/module/data/item-talent.mjs
@@ -20,42 +20,31 @@ export default class GrimwildTalent extends GrimwildItemBase {
 			description: new fields.HTMLField({ required: true, blank: true }),
 		});
 
-		schema.resources = new fields.SchemaField({
-			// Ex: Patron patience, cleric spells.
-			pools: new fields.ArrayField(new fields.SchemaField({
-				label: new fields.StringField(optionalString),
-				description: new fields.StringField(optionalString),
-				value: new DicePoolField(),
-			})),
-			// Ex: Spells, sorcerer essence.
-			points: new fields.ArrayField(new fields.SchemaField({
-				label: new fields.StringField(optionalString),
-				description: new fields.StringField(optionalString),
-				// Whether or not to show checkboxes or just a raw number field.
+		// Resources V2.
+		schema.resources = new fields.ArrayField(new fields.SchemaField({
+			type: new fields.StringField({
+				required: true,
+				blank: false,
+				choices: {
+					pool: 'Pool',
+					points: 'Points',
+				},
+			}),
+			label: new fields.StringField(optionalString),
+			pool: new DicePoolField(),
+			points: new fields.SchemaField({
 				showSteps: new fields.BooleanField(),
-				// Track the actual value numerically.
 				value: new fields.NumberField({
 					...requiredInteger,
-					initial: 0,
+					initial: 1,
 					min: 0,
 				}),
 				max: new fields.NumberField({
+					initial: 1,
 					min: 1,
-				}),
-			})),
-			// Ex: Push on various talents.
-			toggles: new fields.ArrayField(new fields.SchemaField({
-				label: new fields.StringField(optionalString),
-				description: new fields.StringField(optionalString),
-				value: new fields.BooleanField(),
-			})),
-			// Ex: ...maybe not needed? TBD on this one.
-			text: new fields.ArrayField(new fields.SchemaField({
-				label: new fields.StringField(optionalString),
-				description: new fields.StringField(optionalString),
-				value: new fields.StringField(optionalString),
-			})),
-		});
+				})
+			})
+		}));
 
 		return schema;
 	}

--- a/src/module/documents/item.mjs
+++ b/src/module/documents/item.mjs
@@ -62,12 +62,19 @@ export class GrimwildItem extends Item {
 			const result = await roll.evaluate();
 			const dice = result.dice[0].results;
 			const dropped = dice.filter((die) => die.result < 4);
-			await item.update({ "system.roll.diceNum": dice.length - dropped.length });
-			roll.toMessage({
+			// Send to chat.
+			const msg = await roll.toMessage({
 				speaker: speaker,
 				rollMode: rollMode,
 				flavor: label
 			});
+			// Wait for Dice So Nice if enabled.
+			if (game.dice3d && msg?.id) {
+				await game.dice3d.waitFor3DAnimationByMessageID(msg.id);
+			}
+			// Update the item.
+			await item.update({ "system.roll.diceNum": dice.length - dropped.length });
+
 			return roll;
 		}
 	}

--- a/src/module/grimwild.mjs
+++ b/src/module/grimwild.mjs
@@ -25,6 +25,7 @@ globalThis.grimwild = {
 	},
 	applications: {
 		GrimwildActorSheet,
+		GrimwildActorSheetVue,
 		GrimwildItemSheet,
 	},
 	utils: {
@@ -78,6 +79,11 @@ Hooks.once("init", function () {
 
 	// Register sheet application classes
 	Actors.unregisterSheet("core", ActorSheet);
+	Actors.registerSheet("grimwild", GrimwildActorSheet, {
+		makeDefault: true,
+		label: "GRIMWILD.SheetLabels.Actor",
+		types: ["npc"]
+	})
 	Actors.registerSheet("grimwild", GrimwildActorSheetVue, {
 		makeDefault: true,
 		label: "GRIMWILD.SheetLabels.Actor",

--- a/src/module/grimwild.mjs
+++ b/src/module/grimwild.mjs
@@ -5,6 +5,7 @@ import { GrimwildItem } from "./documents/item.mjs";
 import { GrimwildActorSheet } from "./sheets/actor-sheet.mjs";
 import { GrimwildActorSheetVue } from "./sheets/actor-sheet-vue.mjs";
 import { GrimwildItemSheet } from "./sheets/item-sheet.mjs";
+import { GrimwildItemSheetVue } from './sheets/item-sheet-vue.mjs';
 // Import helper/utility classes and constants.
 import { GRIMWILD } from "./helpers/config.mjs";
 import * as dice from "./dice/_module.mjs";
@@ -27,6 +28,7 @@ globalThis.grimwild = {
 		GrimwildActorSheet,
 		GrimwildActorSheetVue,
 		GrimwildItemSheet,
+		GrimwildItemSheetVue,
 	},
 	utils: {
 		rollItemMacro
@@ -81,7 +83,7 @@ Hooks.once("init", function () {
 	Actors.unregisterSheet("core", ActorSheet);
 	Actors.registerSheet("grimwild", GrimwildActorSheet, {
 		makeDefault: true,
-		label: "GRIMWILD.SheetLabels.Actor",
+		label: "Grimwild Fallback Sheet",
 		types: ["npc"]
 	})
 	Actors.registerSheet("grimwild", GrimwildActorSheetVue, {
@@ -93,6 +95,11 @@ Hooks.once("init", function () {
 	Items.registerSheet("grimwild", GrimwildItemSheet, {
 		makeDefault: true,
 		label: "GRIMWILD.SheetLabels.Item"
+	});
+	Items.registerSheet("grimwild", GrimwildItemSheetVue, {
+		makeDefault: false,
+		label: "Grimwild Vue Sheet",
+		types: ["talent"]
 	});
 
 	// Handlebars utilities.

--- a/src/module/sheets/_vue/_base-vue-item-sheet.mjs
+++ b/src/module/sheets/_vue/_base-vue-item-sheet.mjs
@@ -1,25 +1,15 @@
 const { DOCUMENT_OWNERSHIP_LEVELS } = CONST;
 
-export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.ActorSheetV2 {
-	constructor(options = {}) {
-		super(options);
-		this.#dragDrop = this.#createDragDropHandlers();
-	}
-
+export class GrimwildBaseVueItemSheet extends foundry.applications.sheets.ItemSheetV2 {
 	/** @override */
 	static DEFAULT_OPTIONS = {
-		classes: ["grimwild", "actor"],
+		classes: ["grimwild", "item"],
 		document: null,
 		viewPermission: DOCUMENT_OWNERSHIP_LEVELS.LIMITED,
 		editPermission: DOCUMENT_OWNERSHIP_LEVELS.OWNER,
-		position: {
-			width: 800,
-			height: 600
-		},
 		actions: {
 			onEditImage: this._onEditImage,
-			viewDoc: this._viewDoc,
-			createDoc: this._createDoc,
+			showItemArtwork: this.#onShowItemArtwork,
 			deleteDoc: this._deleteDoc,
 			editEffect: this._viewEffect,
 			createEffect: this._createEffect,
@@ -59,7 +49,7 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	 * @protected
 	 */
 	_onRender(context, options) {
-		this.#dragDrop.forEach((d) => d.bind(this.element));
+		this.#dragDrop?.forEach((d) => d.bind(this.element));
 		// You may want to add other special handling here
 		// Foundry comes with a large number of utility classes, e.g. SearchFilter
 		// That you may want to implement yourself.
@@ -100,83 +90,14 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	}
 
 	/**
-	 * Fetches the embedded document representing the containing HTML element
-	 *
-	 * @param {HTMLElement} target    The element subject to search
-	 * @returns {Item | ActiveEffect} The embedded Item or ActiveEffect
-	 */
-	_getEmbeddedDocument(target) {
-		const docRow = target.closest("li[data-document-class]");
-		if (docRow.dataset.documentClass === "Item") {
-			return this.actor.items.get(docRow.dataset.itemId);
-		}
-		else if (docRow.dataset.documentClass === "ActiveEffect") {
-			const parent =
-				docRow.dataset.parentId === this.actor.id
-					? this.actor
-					: this.actor.items.get(docRow?.dataset.parentId);
-			return parent.effects.get(docRow?.dataset.effectId);
-		} return console.warn("Could not find document class");
-	}
-
-	/**
-	 * Renders an embedded document's sheet
-	 *
-	 * @this GrimwildActorSheet
-	 * @param {PointerEvent} event   The originating click event
-	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-	 * @protected
-	 */
-	static async _viewDoc(event, target) {
-		const doc = this._getEmbeddedDocument(target);
-		doc.sheet.render(true);
-	}
-
-	/**
-	 * Handles item deletion
-	 *
-	 * @this GrimwildActorSheet
-	 * @param {PointerEvent} event   The originating click event
-	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-	 * @protected
-	 */
-	static async _deleteDoc(event, target) {
-		const doc = this._getEmbeddedDocument(target);
-		await doc.delete();
-	}
-
-	/**
-	 * Handle creating a new Owned Item or ActiveEffect for the actor using initial data defined in the HTML dataset
-	 *
-	 * @this GrimwildActorSheet
-	 * @param {PointerEvent} event   The originating click event
-	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
-	 * @private
-	 */
-	static async _createDoc(event, target) {
-		// Retrieve the configured document class for Item or ActiveEffect
-		const docCls = getDocumentClass(target.dataset.documentClass);
-		// Prepare the document creation data by initializing it a default name.
-		const docData = {
-			name: docCls.defaultName({
-				// defaultName handles an undefined type gracefully
-				type: target.dataset.type,
-				parent: this.actor
-			})
-		};
-		// Loop through the dataset and add it to our docData
-		for (const [dataKey, value] of Object.entries(target.dataset)) {
-			// These data attributes are reserved for the action handling
-			if (["action", "documentClass"].includes(dataKey)) continue;
-			// Nested properties require dot notation in the HTML, e.g. anything with `system`
-			// An example exists in spells.hbs, with `data-system.spell-level`
-			// which turns into the dataKey 'system.spellLevel'
-			foundry.utils.setProperty(docData, dataKey, value);
-		}
-
-		// Finally, create the embedded document!
-		await docCls.create(docData, { parent: this.actor });
-	}
+   * Handle header control button clicks to display actor portrait artwork.
+   * @this {ArchmageBaseItemSheetV2}
+   * @param {PointerEvent} event
+   */
+  static #onShowItemArtwork(event) {
+    const {img, name, uuid} = this.document;
+    new ImagePopout(img, {title: name, uuid: uuid}).render(true);
+  }
 
 	/**
 	 * Renders an embedded document's sheet
@@ -225,7 +146,7 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 			name: aeCls.defaultName({
 				// defaultName handles an undefined type gracefully
 				type: target.dataset.type,
-				parent: this.actor
+				parent: this.item
 			})
 		};
 		// Loop through the dataset and add it to our effectData
@@ -239,7 +160,7 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 		}
 
 		// Finally, create the embedded document!
-		await aeCls.create(effectData, { parent: this.actor });
+		await aeCls.create(effectData, { parent: this.item });
 		this.render(true);
 	}
 
@@ -264,14 +185,16 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	 */
 	_getEffect(target) {
 		const li = target.closest(".effect");
-		return this.actor.effects.get(li?.dataset?.effectId);
+		return this.item.effects.get(li?.dataset?.effectId);
 	}
 
-	/** *************
+	/* -------------------------------------------- */
+
+	/**
 	 *
-	 * Drag and Drop
+	 * DragDrop
 	 *
-	 ***************/
+	 */
 
 	/**
 	 * Define whether a user is able to begin a dragstart workflow for a given drag selector
@@ -301,11 +224,16 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	 * @protected
 	 */
 	_onDragStart(event) {
-		const docRow = event.currentTarget.closest("li");
+		const li = event.currentTarget;
 		if ("link" in event.target.dataset) return;
 
-		// Chained operation
-		let dragData = this._getEmbeddedDocument(docRow)?.toDragData();
+		let dragData = null;
+
+		// Active Effect
+		if (li.dataset.effectId) {
+			const effect = this.item.effects.get(li.dataset.effectId);
+			dragData = effect.toDragData();
+		}
 
 		if (!dragData) return;
 
@@ -323,13 +251,14 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	/**
 	 * Callback actions which occur when a dragged element is dropped on a target.
 	 * @param {DragEvent} event       The originating DragEvent
-	 * @returns {Promise|void} The promise for the dropped document, or void.
+	 * @returns {Promise|void} A promise of the thing that was dropped, or void if disallowed.
 	 * @protected
 	 */
 	async _onDrop(event) {
+		if (!this.isEditable) return;
 		const data = TextEditor.getDragEventData(event);
-		const actor = this.actor;
-		const allowed = Hooks.call("dropActorSheetData", actor, this, data);
+		const item = this.item;
+		const allowed = Hooks.call("dropItemSheetData", item, this, data);
 		if (allowed === false) return;
 
 		// Handle different data types
@@ -348,31 +277,44 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	/* -------------------------------------------- */
 
 	/**
-	 * Handle a drop event for an existing embedded Active Effect to sort that Active Effect relative to its siblings
+	 * Handle the dropping of ActiveEffect data onto an Actor Sheet
+	 * @param {DragEvent} event                  The concluding DragEvent which contains drop data
+	 * @param {object} data                      The data transfer extracted from the event
+	 * @returns {Promise<ActiveEffect|boolean>}  The created ActiveEffect object or false if it couldn't be created.
+	 * @protected
+	 */
+	async _onDropActiveEffect(event, data) {
+		if (!this.isEditable) return false;
+		const aeCls = getDocumentClass("ActiveEffect");
+		const effect = await aeCls.fromDropData(data);
+		if (!this.item.isOwner || !effect) return false;
+
+		if (this.item.uuid === effect.parent?.uuid) return this._onEffectSort(event, effect);
+		return aeCls.create(effect, { parent: this.item });
+	}
+
+	/**
+	 * Sorts an Active Effect based on its surrounding attributes
 	 *
 	 * @param {DragEvent} event
 	 * @param {ActiveEffect} effect
-	 * @returns {Promise|Array|void} Promise for the update, an array of effects, or void.
+	 * @returns {Promise|void} Promise for the update applied, or void.
 	 */
-	async _onSortActiveEffect(event, effect) {
-		/** @type {HTMLElement} */
+	_onEffectSort(event, effect) {
+		if (!this.isEditable) return;
+		const effects = this.item.effects;
 		const dropTarget = event.target.closest("[data-effect-id]");
 		if (!dropTarget) return;
-		const target = this._getEmbeddedDocument(dropTarget);
+		const target = effects.get(dropTarget.dataset.effectId);
 
 		// Don't sort on yourself
-		if (effect.uuid === target.uuid) return;
+		if (effect.id === target.id) return;
 
 		// Identify sibling items based on adjacent HTML elements
 		const siblings = [];
-		for (const el of dropTarget.parentElement.children) {
+		for (let el of dropTarget.parentElement.children) {
 			const siblingId = el.dataset.effectId;
-			const parentId = el.dataset.parentId;
-			if (
-				siblingId
-        && parentId
-        && (siblingId !== effect.id || parentId !== effect.parent.id)
-			) siblings.push(this._getEmbeddedDocument(el));
+			if (siblingId && siblingId !== effect.id) siblings.push(effects.get(el.dataset.effectId));
 		}
 
 		// Perform the sort
@@ -380,32 +322,17 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 			target,
 			siblings
 		});
+		const updateData = sortUpdates.map((u) => {
+			const update = u.update;
+			update._id = u.target._id;
+			return update;
+		});
 
-		// Split the updates up by parent document
-		const directUpdates = [];
-
-		const grandchildUpdateData = sortUpdates.reduce((items, u) => {
-			const parentId = u.target.parent.id;
-			const update = { _id: u.target.id, ...u.update };
-			if (parentId === this.actor.id) {
-				directUpdates.push(update);
-				return items;
-			}
-			if (items[parentId]) items[parentId].push(update);
-			else items[parentId] = [update];
-			return items;
-		}, {});
-
-		// Effects-on-items updates
-		for (const [itemId, updates] of Object.entries(grandchildUpdateData)) {
-			await this.actor.items
-				.get(itemId)
-				.updateEmbeddedDocuments("ActiveEffect", updates);
-		}
-
-		// Update on the main actor
-		return this.actor.updateEmbeddedDocuments("ActiveEffect", directUpdates);
+		// Perform the update
+		return this.item.updateEmbeddedDocuments("ActiveEffect", updateData);
 	}
+
+	/* -------------------------------------------- */
 
 	/**
 	 * Handle dropping of an Actor data onto another Actor sheet
@@ -416,7 +343,8 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	 * @protected
 	 */
 	async _onDropActor(event, data) {
-		if (!this.actor.isOwner) return false;
+		if (!this.isEditable) return false;
+		if (!this.item.isOwner) return false;
 	}
 
 	/* -------------------------------------------- */
@@ -429,15 +357,11 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	 * @protected
 	 */
 	async _onDropItem(event, data) {
-		if (!this.actor.isOwner) return false;
-		const item = await Item.implementation.fromDropData(data);
-
-		// Handle item sorting within the same Actor
-		if (this.actor.uuid === item.parent?.uuid) return this._onSortItem(event, item);
-
-		// Create the owned item
-		return this._onDropItemCreate(item, event);
+		if (!this.isEditable) return false;
+		if (!this.item.isOwner) return false;
 	}
+
+	/* -------------------------------------------- */
 
 	/**
 	 * Handle dropping of a Folder on an Actor Sheet.
@@ -448,68 +372,8 @@ export class GrimwildBaseVueActorSheet extends foundry.applications.sheets.Actor
 	 * @protected
 	 */
 	async _onDropFolder(event, data) {
-		if (!this.actor.isOwner) return [];
-		const folder = await Folder.implementation.fromDropData(data);
-		if (folder.type !== "Item") return [];
-		const droppedItemData = await Promise.all(
-			folder.contents.map(async (item) => {
-				if (!(document instanceof Item)) item = await fromUuid(item.uuid);
-				return item;
-			})
-		);
-		return this._onDropItemCreate(droppedItemData, event);
-	}
-
-	/**
-	 * Handle the final creation of dropped Item data on the Actor.
-	 * This method is factored out to allow downstream classes the opportunity to override item creation behavior.
-	 * @param {object[]|object} itemData      The item data requested for creation
-	 * @param {DragEvent} event               The concluding DragEvent which provided the drop data
-	 * @returns {Promise<Item[]>}
-	 * @private
-	 */
-	async _onDropItemCreate(itemData, event) {
-		itemData = itemData instanceof Array ? itemData : [itemData];
-		return this.actor.createEmbeddedDocuments("Item", itemData);
-	}
-
-	/**
-	 * Handle a drop event for an existing embedded Item to sort that Item relative to its siblings
-	 * @param {Event} event
-	 * @param {Item} item
-	 * @returns {Promise|void} The document update, or void.
-	 * @private
-	 */
-	_onSortItem(event, item) {
-		// Get the drag source and drop target
-		const items = this.actor.items;
-		const dropTarget = event.target.closest("[data-item-id]");
-		if (!dropTarget) return;
-		const target = items.get(dropTarget.dataset.itemId);
-
-		// Don't sort on yourself
-		if (item.id === target.id) return;
-
-		// Identify sibling items based on adjacent HTML elements
-		const siblings = [];
-		for (let el of dropTarget.parentElement.children) {
-			const siblingId = el.dataset.itemId;
-			if (siblingId && siblingId !== item.id) siblings.push(items.get(el.dataset.itemId));
-		}
-
-		// Perform the sort
-		const sortUpdates = SortingHelpers.performIntegerSort(item, {
-			target,
-			siblings
-		});
-		const updateData = sortUpdates.map((u) => {
-			const update = u.update;
-			update._id = u.target._id;
-			return update;
-		});
-
-		// Perform the update
-		return this.actor.updateEmbeddedDocuments("Item", updateData);
+		if (!this.isEditable) return [];
+		if (!this.item.isOwner) return [];
 	}
 
 	/* -------------------------------------------- */

--- a/src/module/sheets/actor-sheet-vue.mjs
+++ b/src/module/sheets/actor-sheet-vue.mjs
@@ -183,20 +183,6 @@ export class GrimwildActorSheetVue extends VueRenderingMixin(GrimwildBaseVueActo
 		}
 	}
 
-	/**
-	 * Organize and classify Items for Actor sheets.
-	 *
-	 * @param {object} context The context object to mutate.
-	 */
-	_prepareItems(context) {
-		context.items = this.document.items;
-		context.itemTypes = this.document.itemTypes;
-
-		for (const [type, items] of Object.entries(context.itemTypes)) {
-			context.itemTypes[type] = items.sort((a, b) => (a.sort || 0) - (b.sort || 0));
-		}
-	}
-
 	/* -------------------------------------------- */
 
 	/** ************

--- a/src/module/sheets/actor-sheet-vue.mjs
+++ b/src/module/sheets/actor-sheet-vue.mjs
@@ -158,7 +158,7 @@ export class GrimwildActorSheetVue extends VueRenderingMixin(GrimwildBaseVueActo
 		context.tabs.primary.details = {
 			key: 'details',
 			label: game.i18n.localize('GRIMWILD.Actor.Tabs.Details'),
-			active: true,
+			active: false,
 		};
 
 		// Tabs limited to NPCs.
@@ -166,7 +166,7 @@ export class GrimwildActorSheetVue extends VueRenderingMixin(GrimwildBaseVueActo
 			context.tabs.primary.talents = {
 				key: 'talents',
 				label: game.i18n.localize('GRIMWILD.Actor.Tabs.Talents'),
-				active: false,
+				active: true,
 			};
 		}
 

--- a/src/module/sheets/actor-sheet.mjs
+++ b/src/module/sheets/actor-sheet.mjs
@@ -17,7 +17,7 @@ export class GrimwildActorSheet extends api.HandlebarsApplicationMixin(
 
 	/** @override */
 	static DEFAULT_OPTIONS = {
-		classes: ["grimwild", "actor"],
+		classes: ["grimwild", "actor", "monster"],
 		document: null,
 		viewPermission: DOCUMENT_OWNERSHIP_LEVELS.LIMITED,
 		editPermission: DOCUMENT_OWNERSHIP_LEVELS.OWNER,

--- a/src/module/sheets/item-sheet-vue.mjs
+++ b/src/module/sheets/item-sheet-vue.mjs
@@ -35,12 +35,6 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 					label: "ITEM.ViewArt",
 					ownership: "OWNER"
 				},
-				{
-					action: "parseInlineRolls",
-					icon: "fa-solid fa-dice",
-					label: "ARCHMAGE.UI.parseInlineRolls",
-					ownership: "OWNER"
-				}
 			]
 		},
 		tag: "form",

--- a/src/module/sheets/item-sheet-vue.mjs
+++ b/src/module/sheets/item-sheet-vue.mjs
@@ -96,7 +96,7 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 			toggled: true,
 			collaborate: true,
 			documentUUID: this.document.uuid,
-			height: 300,
+			height: 200,
 		};
 
 		// Handle enriching fields.
@@ -127,16 +127,17 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 		// Enrich other fields.
 		const fields = [
 			'description',
+			'notes.description'
 		];
 
 		for (let field of fields) {
+			const editorValue = this.item.system?.[field] ?? foundry.utils.getProperty(this.item.system, field);
 			context.editors[`system.${field}`] = {
-
-				enriched: await TextEditor.enrichHTML(this.item.system[field], enrichmentOptions),
+				enriched: await TextEditor.enrichHTML(editorValue, enrichmentOptions),
 				element: foundry.applications.elements.HTMLProseMirrorElement.create({
 					...editorOptions,
 					name: `system.${field}`,
-					value: context.system?.[field] ?? '',
+					value: editorValue ?? '',
 				}),
 			};
 		}

--- a/src/module/sheets/item-sheet-vue.mjs
+++ b/src/module/sheets/item-sheet-vue.mjs
@@ -1,0 +1,186 @@
+import VueRenderingMixin from "./_vue/_vue-application-mixin.mjs";
+import { GrimwildBaseVueItemSheet } from "./_vue/_base-vue-item-sheet.mjs";
+import { ItemSheetVue } from '../../vue/components.vue.es.mjs';
+
+const { DOCUMENT_OWNERSHIP_LEVELS } = CONST;
+
+export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemSheet) {
+	vueParts = {
+		'item-sheet': {
+			component: ItemSheetVue,
+			template: `<item-sheet :context="context">Vue rendering for sheet failed.</item-sheet>`
+		}
+	}
+
+	constructor(options = {}) {
+		super(options);
+	}
+
+	/** @override */
+	static DEFAULT_OPTIONS = {
+		classes: ["grimwild", "item"],
+		document: null,
+		viewPermission: DOCUMENT_OWNERSHIP_LEVELS.LIMITED,
+		editPermission: DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+		position: {
+			width: 478,
+			// height: 720,
+		},
+		window: {
+			resizable: true,
+			controls: [
+				{
+					action: "showItemArtwork",
+					icon: "fa-solid fa-image",
+					label: "ITEM.ViewArt",
+					ownership: "OWNER"
+				},
+				{
+					action: "parseInlineRolls",
+					icon: "fa-solid fa-dice",
+					label: "ARCHMAGE.UI.parseInlineRolls",
+					ownership: "OWNER"
+				}
+			]
+		},
+		tag: "form",
+		actions: {
+			onEditImage: this._onEditImage,
+			editEffect: this._viewEffect,
+			createEffect: this._createEffect,
+			deleteEffect: this._deleteEffect,
+			toggleEffect: this._toggleEffect,
+		},
+		// Custom property that's merged into `this.options`
+		dragDrop: [{ dragSelector: "[data-drag]", dropSelector: null }],
+		form: {
+			submitOnChange: true,
+			submitOnClose: true,
+		}
+	};
+
+	async _prepareContext(options) {
+		// Output initialization
+		const context = {
+			// Validates both permissions and compendium status
+			editable: this.isEditable,
+			owner: this.document.isOwner,
+			limited: this.document.limited,
+			// Documents.
+			item: this.item.toObject(),
+			actor: this.actor?.toObject() ?? false,
+			// Add the actor's data to context.data for easier access, as well as flags.
+			system: this.item.system,
+			flags: this.item.flags,
+			// Roll data.
+			rollData: this.item.getRollData() ?? {},
+			// Adding a pointer to CONFIG.GRIMWILD
+			config: CONFIG.GRIMWILD,
+			// Force re-renders. Defined in the vue mixin.
+			_renderKey: this._renderKey ?? 0,
+			// Necessary for formInput and formFields helpers
+			fields: this.document.schema.fields,
+			systemFields: this.document.system.schema.fields
+		};
+
+		// Handle tabs.
+		this._prepareTabs(context);
+
+		// Handle enriched fields.
+		const enrichmentOptions = {
+			// Whether to show secret blocks in the finished html
+			secrets: this.document.isOwner,
+			// Data to fill in for inline rolls
+			rollData: this.item.getRollData() ?? {},
+			// Relative UUID resolution
+			relativeTo: this.item
+		};
+
+		const editorOptions = {
+			toggled: true,
+			collaborate: true,
+			documentUUID: this.document.uuid,
+			height: 300,
+		};
+
+		// Handle enriching fields.
+		context.editors = {};
+		await this._enrichFields(context, enrichmentOptions, editorOptions);
+
+		// Make another pass through the editors to fix the element contents.
+		for (let [field, editor] of Object.entries(context.editors)) {
+			if (context.editors?.[field].element) {
+				context.editors[field].element.innerHTML = context.editors[field].enriched;
+			}
+		}
+
+		// Debug. @todo remove.
+		console.log('context', context);
+
+		return context;
+	}
+
+	/**
+	 * Enrich values for action fields.
+	 * 
+	 * @param {object} context 
+	 * @param {object} enrichmentOptions 
+	 * @param {object} editorOptions 
+	 */
+	async _enrichFields(context, enrichmentOptions, editorOptions) {
+		// Enrich other fields.
+		const fields = [
+			'description',
+		];
+
+		for (let field of fields) {
+			context.editors[`system.${field}`] = {
+
+				enriched: await TextEditor.enrichHTML(this.item.system[field], enrichmentOptions),
+				element: foundry.applications.elements.HTMLProseMirrorElement.create({
+					...editorOptions,
+					name: `system.${field}`,
+					value: context.system?.[field] ?? '',
+				}),
+			};
+		}
+	}
+
+	/**
+	 * Prepare tabs for Vue.
+	 * 
+	 * @param {object} context 
+	 */
+	_prepareTabs(context) {
+		// Initialize tabs.
+		context.tabs = {
+			primary: {},
+		};
+
+		// Tabs available to all items.
+		context.tabs.primary.description = {
+			key: 'description',
+			label: game.i18n.localize('GRIMWILD.Item.Tabs.Description'),
+			active: true,
+		};
+
+		// Tabs limited to NPCs.
+		context.tabs.primary.attributes = {
+			key: 'attributes',
+			label: game.i18n.localize('GRIMWILD.Item.Tabs.Attributes'),
+			active: false,
+		};
+
+		// More tabs available to all items.
+		context.tabs.primary.effects = {
+			key: 'effects',
+			label: game.i18n.localize('GRIMWILD.Item.Tabs.Effects'),
+			active: false,
+		};
+
+		// Ensure we have a default tab.
+		if (this.item.type !== 'talent') {
+			context.tabs.primary.details.active = true;
+		}
+	}
+}

--- a/src/module/sheets/item-sheet-vue.mjs
+++ b/src/module/sheets/item-sheet-vue.mjs
@@ -44,6 +44,8 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 			createEffect: this._createEffect,
 			deleteEffect: this._deleteEffect,
 			toggleEffect: this._toggleEffect,
+			createResource: this._createResource,
+			deleteResource: this._deleteResource,
 		},
 		// Custom property that's merged into `this.options`
 		dragDrop: [{ dragSelector: "[data-drag]", dropSelector: null }],
@@ -155,14 +157,14 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 		context.tabs.primary.description = {
 			key: 'description',
 			label: game.i18n.localize('GRIMWILD.Item.Tabs.Description'),
-			active: true,
+			active: false,
 		};
 
 		// Tabs limited to NPCs.
 		context.tabs.primary.attributes = {
 			key: 'attributes',
 			label: game.i18n.localize('GRIMWILD.Item.Tabs.Attributes'),
-			active: false,
+			active: true,
 		};
 
 		// More tabs available to all items.
@@ -175,6 +177,57 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 		// Ensure we have a default tab.
 		if (this.item.type !== 'talent') {
 			context.tabs.primary.details.active = true;
+		}
+	}
+
+	/* -------------------------------------------- */
+
+	/** ************
+	 *
+	 *   ACTIONS
+	 *
+	 **************/
+
+	/**
+	 * Handle creating a new resource entry.
+	 *
+	 * @this GrimwildActorSheet
+	 * @param {PointerEvent} event   The originating click event
+	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+	 * @private
+	 */
+	static async _createResource(event, target) {
+		event.preventDefault();
+		const { resourceType } = target.dataset;
+		const resources = this.document.system.resources?.[resourceType];
+		if (!resources) return;
+
+		resources.push({});
+		await this.document.update({
+			[`system.resources.${resourceType}`]: resources,
+		});
+	}
+
+	/**
+	 * Handle deleting an existing resource entry.
+	 *
+	 * @this GrimwildActorSheet
+	 * @param {PointerEvent} event   The originating click event
+	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+	 * @private
+	 */
+	static async _deleteResource(event, target) {
+		event.preventDefault();
+		const { resourceType, key } = target.dataset;
+		if (resourceType && key) {
+			const resources = this.document.system.resources?.[resourceType];
+			if (!resources) return;
+
+			resources.splice(Number(key), 1);
+
+			await this.document.update({
+				[`system.resources.${resourceType}`]: resources,
+			});
 		}
 	}
 }

--- a/src/module/sheets/item-sheet-vue.mjs
+++ b/src/module/sheets/item-sheet-vue.mjs
@@ -111,7 +111,7 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 		}
 
 		// Debug. @todo remove.
-		console.log('context', context);
+		// console.log('context', context);
 
 		return context;
 	}

--- a/src/module/sheets/item-sheet-vue.mjs
+++ b/src/module/sheets/item-sheet-vue.mjs
@@ -199,14 +199,18 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 	 */
 	static async _createResource(event, target) {
 		event.preventDefault();
-		const { resourceType } = target.dataset;
-		const resources = this.document.system.resources?.[resourceType];
+		const resources = this.document.system.resources;
 		if (!resources) return;
 
-		resources.push({});
-		await this.document.update({
-			[`system.resources.${resourceType}`]: resources,
+		resources.push({
+			type: 'points',
+			points: {
+				value: 1,
+				max: 1,
+				showSteps: true,
+			},
 		});
+		await this.document.update({'system.resources': resources});
 	}
 
 	/**
@@ -219,16 +223,14 @@ export class GrimwildItemSheetVue extends VueRenderingMixin(GrimwildBaseVueItemS
 	 */
 	static async _deleteResource(event, target) {
 		event.preventDefault();
-		const { resourceType, key } = target.dataset;
-		if (resourceType && key) {
-			const resources = this.document.system.resources?.[resourceType];
+		const { key } = target.dataset;
+		if (key) {
+			const resources = this.document.system.resources;
 			if (!resources) return;
 
 			resources.splice(Number(key), 1);
 
-			await this.document.update({
-				[`system.resources.${resourceType}`]: resources,
-			});
+			await this.document.update({'system.resources': resources});
 		}
 	}
 }

--- a/src/styles/components/_items.scss
+++ b/src/styles/components/_items.scss
@@ -76,8 +76,8 @@
     .item-name {
       color: $c-dark;
       .item-image {
-        flex: 0 0 30px;
-        height: 30px;
+        // flex: 0 0 30px;
+        // height: 30px;
         background-size: 30px;
         border: none;
         margin-right: 5px;

--- a/src/styles/components/_items.scss
+++ b/src/styles/components/_items.scss
@@ -58,7 +58,7 @@
   // Control Buttons
   .item-controls {
     display: flex;
-    flex: 0 0 100px;
+    flex: 0 0 60px;
     justify-content: flex-end;
     a {
       font-size: 12px;

--- a/src/styles/components/_items.scss
+++ b/src/styles/components/_items.scss
@@ -72,9 +72,17 @@
     align-items: center;
     padding: 0 2px; // to align with the header border
     border-bottom: 1px solid $c-faint;
+
     &:last-child { border-bottom: none; }
+
     .item-name {
       color: $c-dark;
+      cursor: pointer;
+
+      &:hover {
+        color: #ffffff;
+      }
+
       .item-image {
         // flex: 0 0 30px;
         // height: 30px;
@@ -84,6 +92,22 @@
       }
     }
   }
+
+  // Start height animation styling. -------------------
+  .item-description-wrapper {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.25s ease-in-out;
+  }
+
+  .item.active .item-description-wrapper {
+    grid-template-rows: 1fr;
+  }
+
+  .item-description {
+    overflow: hidden;
+  }
+  // End height animation styling. ---------------------
 
   .item-prop {
     text-align: center;

--- a/src/styles/components/_items.scss
+++ b/src/styles/components/_items.scss
@@ -93,6 +93,7 @@
     }
   }
 
+  // @see https://keithjgrant.com/posts/2023/04/transitioning-to-height-auto/
   // Start height animation styling. -------------------
   .item-description-wrapper {
     display: grid;

--- a/src/styles/components/_monster.scss
+++ b/src/styles/components/_monster.scss
@@ -1,0 +1,18 @@
+&.monster {
+  .item-image {
+    flex: 0 0 24px;
+  }
+
+  .item-name {
+    gap: 8px;
+
+    .rollable {
+      flex: 0 auto;
+      flex-wrap: nowrap;
+    }
+  }
+
+  .challenge-pool {
+    color: #ffffff;
+  }
+}

--- a/src/styles/components/_resource.scss
+++ b/src/styles/components/_resource.scss
@@ -1,12 +1,12 @@
-.resource-label {
-  font-weight: bold;
-}
+// .resource-label {
+//   font-weight: bold;
+// }
 
-.ability {
-  margin-bottom: 2px;
-}
+// .ability {
+//   margin-bottom: 2px;
+// }
 
-.ability-score,
-.ability-mod {
-  flex: 0 0 44px;
-}
+// .ability-score,
+// .ability-mod {
+//   flex: 0 0 44px;
+// }

--- a/src/styles/components/_resources.scss
+++ b/src/styles/components/_resources.scss
@@ -5,16 +5,37 @@
     flex: 0;
   }
 
+  .resource-create {
+    flex: 1;
+  }
+
   .resource-steps {
     flex: 0 0 120px;
   }
 
-  .resource-type {
-    padding: 10px 0;
-    align-items: flex-start;
+  .resource-values {
+    gap: 0;
+  }
 
-    + .resource-type {
+  .resources-group {
+    padding: 0.5rem 0;
+    align-items: flex-start;
+    gap: 0.2rem 0.5rem;
+
+    .form-group.stacked {
+      gap: 0.2rem 0.5rem;
+    }
+
+    label {
+      padding-top: 0.2rem;
+    }
+
+    + .resources-group {
       border-top: 1px solid var(--color-border-light-tertiary);
     }
+  }
+
+  .resource-type {
+    flex: 0 auto;
   }
 }

--- a/src/styles/components/_resources.scss
+++ b/src/styles/components/_resources.scss
@@ -1,0 +1,20 @@
+.resources {
+  .resource-type-label,
+  .resource-control,
+  .resource-value {
+    flex: 0;
+  }
+
+  .resource-steps {
+    flex: 0 0 120px;
+  }
+
+  .resource-type {
+    padding: 10px 0;
+    align-items: flex-start;
+
+    + .resource-type {
+      border-top: 1px solid var(--color-border-light-tertiary);
+    }
+  }
+}

--- a/src/styles/components/_talents.scss
+++ b/src/styles/components/_talents.scss
@@ -1,0 +1,36 @@
+.talents {
+  .talent {
+    padding: 4px 0;
+    margin: 0;
+
+    + .talent {
+      border-top: 1px solid #ffffff22;
+    }
+  }
+
+  .item-resources {
+    flex: 0 0 auto;
+  }
+
+  .resource {
+    background: #ffffff11;
+    padding: 2px;
+    border-radius: 4px;
+    margin: 1px;
+    flex-wrap: nowrap;
+
+    strong {
+      padding: 0 8px;
+    }
+  }
+
+  .resource-steps {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    input[type="checkbox"] {
+      margin: 0;
+    }
+  }
+}

--- a/src/styles/components/_talents.scss
+++ b/src/styles/components/_talents.scss
@@ -8,8 +8,18 @@
     }
   }
 
+  .item-summary {
+    width: 100%;
+  }
+
   .item-resources {
     flex: 0 0 auto;
+  }
+
+  .item-notes {
+    background: #ffffff11;
+    padding: 8px;
+    border-radius: 4px;
   }
 
   .resource {

--- a/src/styles/components/_talents.scss
+++ b/src/styles/components/_talents.scss
@@ -34,6 +34,10 @@
     }
   }
 
+  .resource-value-numeric {
+    white-space: nowrap;
+  }
+
   .resource-steps {
     flex-wrap: nowrap;
     justify-content: flex-start;

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -16,12 +16,13 @@
 /* Styles limited to grimwild sheets */
 .grimwild {
   @import 'components/forms';
-  @import 'components/resource';
+  // @import 'components/resource';
   @import 'components/items';
   @import 'components/effects';
   @import 'components/stats';
   @import 'components/backgrounds';
   @import 'components/monster';
+  @import 'components/resources';
 }
 
 .chat-message {

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -21,6 +21,7 @@
   @import 'components/effects';
   @import 'components/stats';
   @import 'components/backgrounds';
+  @import 'components/monster';
 }
 
 .chat-message {

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -23,6 +23,7 @@
   @import 'components/backgrounds';
   @import 'components/monster';
   @import 'components/resources';
+  @import 'components/talents';
 }
 
 .chat-message {

--- a/src/system.yml
+++ b/src/system.yml
@@ -29,6 +29,7 @@ documentTypes:
     equipment:
       htmlFields:
       - description
+      - notes.description
     challenge:
       htmlFields:
       - description

--- a/src/templates/actor/challenges.hbs
+++ b/src/templates/actor/challenges.hbs
@@ -32,17 +32,18 @@
             data-drag='true'
             data-document-class='Item'
           >
-            <div class='item-name'>
-              <div class='item-image'>
-                <a class='rollable' data-roll-type='item' data-action='roll'>
+            <div class='item-name flexrow'>
+              <a class='rollable flexrow' data-roll-type='item' data-action='roll'>
+                <div class='item-image'>
                   <img
                     src='{{item.img}}'
                     title='{{item.name}}'
                     width='24'
                     height='24'
                   />
-                </a>
-              </div>
+                </div>
+                <div class="challenge-pool">[{{item.system.roll.diceNum}}d]</div>
+              </a>
               <div>{{item.name}}</div>
             </div>
             <div class='item-controls'>

--- a/src/vue/ItemSheet.vue
+++ b/src/vue/ItemSheet.vue
@@ -1,0 +1,57 @@
+<template>
+	<div :class="`grimwild-vue standard-form flexcol`">
+		<div class="grimwild-sheet-layout flexcol">
+			<!-- <CharSidebar :context="context" /> -->
+	
+			<!-- Header -->
+			 <section class="grimwild-main flexcol grid-span-3">
+				<ItemHeader :context="context" />
+
+				
+				<div class="section--main flexcol">
+					<!-- Tab links -->
+					<Tabs :tabs="tabs.primary" no-span="true"/>
+
+					<section class="section--fields">
+						<!-- Details fields -->
+						<Tab group="primary" :tab="tabs.primary.description">
+							<ItemDescription :item="context.item" :context="context"/>
+						</Tab>
+				
+						<!-- Attack fields -->
+						<Tab group="primary" :tab="tabs.primary.attributes">
+							Attributes
+							<!-- <CharTalents :actor="context.actor" :context="context"/> -->
+						</Tab>
+		
+						<!-- Active Effect Fields -->
+						<Tab group="primary" :tab="tabs.primary.effects">
+							Effects
+							<!-- <CharEffects :actor="context.actor" :context="context" :key="context._renderKey"/> -->
+						</Tab>
+					</section>
+				</div>
+			 </section>
+		</div>
+
+	</div>
+</template>
+
+<script setup>
+import {
+	Tabs,
+	Tab,
+	ItemHeader,
+	ItemDescription,
+} from '@/components';
+import { reactive, toRaw } from 'vue';
+
+const props = defineProps(['context']);
+// Convert the tabs into a new reactive variable so that they
+// don't change every time the item is updated.
+const rawTabs = toRaw(props.context.tabs);
+const tabs = reactive({...rawTabs});
+// Retrieve a copy of the full item document instance provided by
+// the VueApplicationMixin.
+// const item = inject('rawDocument');
+</script>

--- a/src/vue/ItemSheet.vue
+++ b/src/vue/ItemSheet.vue
@@ -20,8 +20,7 @@
 				
 						<!-- Attack fields -->
 						<Tab group="primary" :tab="tabs.primary.attributes">
-							Attributes
-							<!-- <CharTalents :actor="context.actor" :context="context"/> -->
+							<ItemAttributes :context="context" />
 						</Tab>
 		
 						<!-- Active Effect Fields -->
@@ -43,6 +42,7 @@ import {
 	Tab,
 	ItemHeader,
 	ItemDescription,
+	ItemAttributes
 } from '@/components';
 import { reactive, toRaw } from 'vue';
 

--- a/src/vue/ItemSheet.vue
+++ b/src/vue/ItemSheet.vue
@@ -15,7 +15,19 @@
 					<section class="section--fields">
 						<!-- Details fields -->
 						<Tab group="primary" :tab="tabs.primary.description">
+							<!-- Description -->
 							<ItemDescription :item="context.item" :context="context"/>
+							<!-- Notes -->
+							<fieldset v-if="context.item.type === 'talent'">
+								<legend>Notes</legend>
+								<div class="notes form-group stacked">
+									<label>Label</label>
+									<input type="text" :name="`system.notes.label`" v-model="context.system.notes.label"/>
+								</div>
+								<div class="field">
+									<Prosemirror :editable="context.editable" :field="context.editors['system.notes.description']"/>
+								</div>
+							</fieldset>
 						</Tab>
 				
 						<!-- Attack fields -->
@@ -42,7 +54,8 @@ import {
 	Tab,
 	ItemHeader,
 	ItemDescription,
-	ItemAttributes
+	ItemAttributes,
+	Prosemirror
 } from '@/components';
 import { reactive, toRaw } from 'vue';
 

--- a/src/vue/components/actor/character/CharTalents.vue
+++ b/src/vue/components/actor/character/CharTalents.vue
@@ -17,7 +17,7 @@
 				</div>
 			</li>
 			<li v-for="(item, id) in context.itemTypes.talent" :key="id"
-				class="item talent flexcol"
+				:class="`item talent flexcol ${context.activeItems?.[item._id] ? 'active' : ''}`"
 				:data-item-id="item._id"
 				data-drag="true"
 				draggable="true"
@@ -34,7 +34,7 @@
 								/>
 							</a>
 						</div>
-						<div>{{ item.name }}</div>
+						<div data-action="toggleItem" :data-item-id="item._id">{{ item.name }}</div>
 					</div>
 					<div class="item-resources">
 						<template v-for="(resources, resourceType) in item.system.resources" :key="resourceType">
@@ -75,11 +75,13 @@
 						><i class="fas fa-trash"></i></a>
 					</div>
 				</div>
-				<div v-if="item.system.description" class="item-description flexcol">
-					<div class="item-description" v-html="item.system.description"></div>
-					<div v-if="item.system.notes.description" class="item-notes">
-						<strong v-if="item.system.notes.label">{{ item.system.notes.label }}</strong>
-						<div class="item-notes-description" v-html="item.system.notes.description"></div>
+				<div v-if="item.system.description" class="item-description-wrapper">
+					<div class="item-description flexcol">
+						<div class="item-description" v-html="item.system.description"></div>
+						<div v-if="item.system.notes.description" class="item-notes">
+							<strong v-if="item.system.notes.label">{{ item.system.notes.label }}</strong>
+							<div class="item-notes-description" v-html="item.system.notes.description"></div>
+						</div>
 					</div>
 				</div>
 			</li>

--- a/src/vue/components/actor/character/CharTalents.vue
+++ b/src/vue/components/actor/character/CharTalents.vue
@@ -17,61 +17,70 @@
 				</div>
 			</li>
 			<li v-for="(item, id) in context.itemTypes.talent" :key="id"
-				class="item talent flexrow"
+				class="item talent flexcol"
 				:data-item-id="item._id"
 				data-drag="true"
 				draggable="true"
 				data-document-class="Item"
 			>
-				<div class="item-name">
-					<div class="item-image">
-						<a class="rollable" data-roll-type="item" data-action="roll">
-							<img :src="item.img"
-								:title="item.name"
-								width="24"
-								height="24"
-							/>
-						</a>
+				<div class="item-summary flexrow">
+					<div class="item-name">
+						<div class="item-image">
+							<a class="rollable" data-roll-type="item" data-action="roll">
+								<img :src="item.img"
+									:title="item.name"
+									width="24"
+									height="24"
+								/>
+							</a>
+						</div>
+						<div>{{ item.name }}</div>
 					</div>
-					<div>{{ item.name }}</div>
-				</div>
-				<div class="item-resources">
-					<template v-for="(resources, resourceType) in item.system.resources" :key="resourceType">
-						<template v-if="resources.length > 0">
-							<div class="item-resource flexrow">
-								<div v-for="(resource, resourceKey) in resources" :key="resource" class="resource flexrow">
-									<strong v-if="resource.label">{{ resource.label }}</strong>
-									<div class="resource-value">
-										<template v-if="resourceType === 'pools'">
-											[{{ resource.value.diceNum }}d]
-										</template>
-										<template v-if="resourceType === 'points'">
-											<div v-if="resource.showSteps" class="resource-steps flexrow">
-												<template v-for="(num, i) in resource.max" :key="i">
-													<input type="checkbox" :checked="resource.value >= num" readonly />
-												</template>
-											</div>
-											<div v-else class="resource-value">{{ resource.value }} / {{ resource.max }}</div>
-										</template>
-										<template v-if="resourceType === 'toggles'">
-											<input type="checkbox" :checked="resource.value" readonly />
-										</template>
+					<div class="item-resources">
+						<template v-for="(resources, resourceType) in item.system.resources" :key="resourceType">
+							<template v-if="resources.length > 0">
+								<div class="item-resource flexrow">
+									<div v-for="(resource, resourceKey) in resources" :key="resource" class="resource flexrow">
+										<strong v-if="resource.label">{{ resource.label }}</strong>
+										<div class="resource-value">
+											<template v-if="resourceType === 'pools'">
+												[{{ resource.value.diceNum }}d]
+											</template>
+											<template v-if="resourceType === 'points'">
+												<div v-if="resource.showSteps" class="resource-steps flexrow">
+													<template v-for="(num, i) in resource.max" :key="i">
+														<input type="checkbox" :checked="resource.value >= num" readonly />
+													</template>
+												</div>
+												<div v-else class="resource-value">{{ resource.value }} / {{ resource.max }}</div>
+											</template>
+											<template v-if="resourceType === 'toggles'">
+												<input type="checkbox" :checked="resource.value" readonly />
+											</template>
+										</div>
 									</div>
 								</div>
-							</div>
+							</template>
 						</template>
-					</template>
+					</div>
+					<div class="item-controls">
+						<a class="item-control item-edit"
+							:title="game.i18n.format('DOCUMENT.Edit', {type: 'talent'})"
+							data-action="viewDoc"
+						><i class="fas fa-edit"></i></a>
+						<a class="item-control item-delete"
+							v-if="context.editable"
+							:title="game.i18n.format('DOCUMENT.Delete', {type: 'talent'})"
+							data-action="deleteDoc"
+						><i class="fas fa-trash"></i></a>
+					</div>
 				</div>
-				<div class="item-controls">
-					<a class="item-control item-edit"
-						:title="game.i18n.format('DOCUMENT.Edit', {type: 'talent'})"
-						data-action="viewDoc"
-					><i class="fas fa-edit"></i></a>
-					<a class="item-control item-delete"
-						v-if="context.editable"
-						:title="game.i18n.format('DOCUMENT.Delete', {type: 'talent'})"
-						data-action="deleteDoc"
-					><i class="fas fa-trash"></i></a>
+				<div v-if="item.system.description" class="item-description flexcol">
+					<div class="item-description" v-html="item.system.description"></div>
+					<div v-if="item.system.notes.description" class="item-notes">
+						<strong v-if="item.system.notes.label">{{ item.system.notes.label }}</strong>
+						<div class="item-notes-description" v-html="item.system.notes.description"></div>
+					</div>
 				</div>
 			</li>
 		</ol>

--- a/src/vue/components/actor/character/CharTalents.vue
+++ b/src/vue/components/actor/character/CharTalents.vue
@@ -35,6 +35,33 @@
 					</div>
 					<div>{{ item.name }}</div>
 				</div>
+				<div class="item-resources">
+					<template v-for="(resources, resourceType) in item.system.resources" :key="resourceType">
+						<template v-if="resources.length > 0">
+							<div class="item-resource flexrow">
+								<div v-for="(resource, resourceKey) in resources" :key="resource" class="resource flexrow">
+									<strong v-if="resource.label">{{ resource.label }}</strong>
+									<div class="resource-value">
+										<template v-if="resourceType === 'pools'">
+											[{{ resource.value.diceNum }}d]
+										</template>
+										<template v-if="resourceType === 'points'">
+											<div v-if="resource.showSteps" class="resource-steps flexrow">
+												<template v-for="(num, i) in resource.max" :key="i">
+													<input type="checkbox" :checked="resource.value >= num" readonly />
+												</template>
+											</div>
+											<div v-else class="resource-value">{{ resource.value }} / {{ resource.max }}</div>
+										</template>
+										<template v-if="resourceType === 'toggles'">
+											<input type="checkbox" :checked="resource.value" readonly />
+										</template>
+									</div>
+								</div>
+							</div>
+						</template>
+					</template>
+				</div>
 				<div class="item-controls">
 					<a class="item-control item-edit"
 						:title="game.i18n.format('DOCUMENT.Edit', {type: 'talent'})"

--- a/src/vue/components/actor/character/CharTalents.vue
+++ b/src/vue/components/actor/character/CharTalents.vue
@@ -1,6 +1,7 @@
 <template>
 	<section class="grid grid-3col">
 		<ol class="items-list grid-span-3">
+			<!-- Header row -->
 			<li class="item flexrow items-header">
 				<div class="item-name">{{ game.i18n.localize('Name') }}</div>
 				<div class="item-controls">
@@ -11,11 +12,12 @@
 							data-document-class="Item"
 							data-type="talent"
 						>
-							<i class="fas fa-plus"></i>{{ game.i18n.format(`DOCUMENT.New`, {type: 'talent'}) }}
+							<i class="fas fa-plus"></i><span>Add</span>
 						</a>
 					</template>
 				</div>
 			</li>
+			<!-- Talent rows -->
 			<li v-for="(item, id) in context.itemTypes.talent" :key="id"
 				:class="`item talent flexcol ${context.activeItems?.[item._id] ? 'active' : ''}`"
 				:data-item-id="item._id"
@@ -23,7 +25,9 @@
 				draggable="true"
 				data-document-class="Item"
 			>
+				<!-- Summary, always visible -->
 				<div class="item-summary flexrow">
+					<!-- Name and image -->
 					<div class="item-name">
 						<div class="item-image">
 							<a class="rollable" data-roll-type="item" data-action="roll">
@@ -36,31 +40,32 @@
 						</div>
 						<div data-action="toggleItem" :data-item-id="item._id">{{ item.name }}</div>
 					</div>
-					<div class="item-resources">
-						<template v-for="(resources, resourceType) in item.system.resources" :key="resourceType">
-							<template v-if="resources.length > 0">
-								<div class="item-resource flexrow">
-									<div v-for="(resource, resourceKey) in resources" :key="resource" class="resource flexrow">
-										<strong v-if="resource.label">{{ resource.label }}</strong>
-										<div class="resource-value">
-											<template v-if="resourceType === 'pools'">
-												[{{ resource.value.diceNum }}d]
-											</template>
-											<template v-if="resourceType === 'points'">
-												<div v-if="resource.showSteps" class="resource-steps flexrow">
-													<template v-for="(num, i) in resource.max" :key="i">
-														<input type="checkbox" :checked="resource.value >= num" readonly />
-													</template>
-												</div>
-												<div v-else class="resource-value">{{ resource.value }} / {{ resource.max }}</div>
-											</template>
-											<template v-if="resourceType === 'toggles'">
-												<input type="checkbox" :checked="resource.value" readonly />
+					<!-- Resources -->
+					<div class="item-resources flexrow">
+						<!-- Resource -->
+						<template v-for="(resource, resourceKey) in item.system.resources" :key="resourceKey">
+							<div class="resource flexrow">
+								<!-- Resource label -->
+								<strong v-if="resource.label">{{ resource.label }}</strong>
+								<!-- Resource value. -->
+								<div class="resource-value">
+									<!-- Pools -->
+									<template v-if="resource.type === 'pool'">
+										[{{ resource.pool.diceNum }}d]
+									</template>
+									<!-- Points -->
+									<template v-if="resource.type === 'points'">
+										<!-- Checkbox points -->
+										<div v-if="resource.points.showSteps" class="resource-steps flexrow">
+											<template v-for="(num, i) in resource.points.max" :key="i">
+												<input type="checkbox" :checked="resource.points.value >= num" readonly />
 											</template>
 										</div>
-									</div>
+										<!-- Numeric points -->
+										<div v-else class="resource-value-numeric">{{ resource.points.value }} / {{ resource.points.max }}</div>
+									</template>
 								</div>
-							</template>
+							</div>
 						</template>
 					</div>
 					<div class="item-controls">
@@ -75,6 +80,7 @@
 						><i class="fas fa-trash"></i></a>
 					</div>
 				</div>
+				<!-- Description, visible when toggled on. -->
 				<div v-if="item.system.description" class="item-description-wrapper">
 					<div class="item-description flexcol">
 						<div class="item-description" v-html="item.system.description"></div>

--- a/src/vue/components/index.mjs
+++ b/src/vue/components/index.mjs
@@ -4,6 +4,9 @@ export { default as CharHeader } from '@/components/actor/character/CharHeader.v
 export { default as CharDetails } from '@/components/actor/character/CharDetails.vue';
 export { default as CharTalents } from '@/components/actor/character/CharTalents.vue';
 export { default as CharEffects } from '@/components/actor/character/CharEffects.vue';
+// Items.
+export { default as ItemDescription } from '@/components/item/ItemDescription.vue';
+export { default as ItemHeader } from '@/components/item/ItemHeader.vue';
 // Parts.
 export { default as Tabs } from '@/components/parts/Tabs.vue';
 export { default as Tab } from '@/components/parts/Tab.vue';

--- a/src/vue/components/index.mjs
+++ b/src/vue/components/index.mjs
@@ -7,6 +7,8 @@ export { default as CharEffects } from '@/components/actor/character/CharEffects
 // Items.
 export { default as ItemDescription } from '@/components/item/ItemDescription.vue';
 export { default as ItemHeader } from '@/components/item/ItemHeader.vue';
+export { default as ItemAttributes } from '@/components/item/ItemAttributes.vue';
+export { default as TalentResources } from '@/components/item/talent/TalentResources.vue';
 // Parts.
 export { default as Tabs } from '@/components/parts/Tabs.vue';
 export { default as Tab } from '@/components/parts/Tab.vue';

--- a/src/vue/components/item/ItemAttributes.vue
+++ b/src/vue/components/item/ItemAttributes.vue
@@ -1,0 +1,12 @@
+<template>
+	<TalentResources :context="context"/>
+</template>
+
+<script setup>
+import { inject } from 'vue';
+import {
+	TalentResources
+} from '@/components';
+const props = defineProps(['context']);
+const actor = inject('rawDocument');
+</script>

--- a/src/vue/components/item/ItemDescription.vue
+++ b/src/vue/components/item/ItemDescription.vue
@@ -1,0 +1,17 @@
+<template>
+  <fieldset>
+    <legend>{{ context.systemFields.description.label }}</legend>
+    <div class="form-group">
+      <div class="field">
+        <Prosemirror :editable="context.editable" :field="context.editors['system.description']"/>
+      </div>
+    </div>
+  </fieldset>
+</template>
+
+<script setup>
+import {
+	Prosemirror
+} from '@/components';
+const props = defineProps(['item', 'context']);
+</script>

--- a/src/vue/components/item/ItemHeader.vue
+++ b/src/vue/components/item/ItemHeader.vue
@@ -1,0 +1,25 @@
+<template>
+	<header class="sheet-header">
+		<img
+			class="profile-img"
+			:src="context.item.img"
+			data-edit="img"
+			data-action="onEditImage"
+			:title="context.item.name"
+			height="100"
+			width="100"
+		/>
+		<div class="header-fields">
+			<div class="document-name">
+				<input type="text" name="name" v-model="context.item.name" :placeholder="game.i18n.localize('Name')"/>
+			</div>
+		</div>
+	</header>
+</template>
+
+<script setup>
+import { inject } from 'vue';
+const props = defineProps(['context']);
+const item = inject('rawDocument');
+
+</script>

--- a/src/vue/components/item/talent/TalentResources.vue
+++ b/src/vue/components/item/talent/TalentResources.vue
@@ -1,0 +1,148 @@
+<template>
+	<fieldset class="resources">
+		<legend>{{ context.systemFields.resources.label }}</legend>
+		<!-- RESOUCE POOLS -->
+		<div class="resource-type resource-pools form-group">
+			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.pools')}}</label>
+			<a class="resource-control resource-create"
+				title="Add pool"
+				data-action="createResource"
+				data-resource-type="pools"
+			><i class="fas fa-plus"></i></a>
+			<!-- Pool values -->
+			<div class="resource-values form-group stacked">
+				<div v-for="(pool, poolKey) in context.system.resources.pools" :key="poolKey" class="form-group pools-group">
+					<!-- Label -->
+					<div class="resource-label form-group stacked">
+						<label>Label</label>
+						<input type="text" :name="`system.resources.pools.${poolKey}.label`" v-model="pool.label"/>
+					</div>
+					<!-- Value -->
+					<div class="resource-value form-group stacked">
+						<label>Value</label>
+						<input type="number" :name="`system.resources.pools.${poolKey}.value.diceNum`" v-model="pool.value.diceNum"/>
+					</div>
+					<!-- Delete control -->
+					<a class="resource-control resource-delete"
+						title="Delete pool"
+						data-action="deleteResource"
+						data-resource-type="pools"
+						:data-key="poolKey"
+					><i class="fas fa-trash"></i></a>
+				</div>
+			</div>
+		</div>
+		<!-- RESOURCE POINTS -->
+		<div class="resource-type resource-points form-group">
+			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.points')}}</label>
+			<a class="resource-control resource-create"
+				title="Add points"
+				data-action="createResource"
+				data-resource-type="points"
+			><i class="fas fa-plus"></i></a>
+			<!-- Point values -->
+			<div class="resource-values form-group stacked">
+				<div v-for="(point, pointKey) in context.system.resources.points" :key="pointKey" class="form-group points-group">
+					<!-- Label -->
+					<div class="resource-label form-group stacked">
+						<label>Label</label>
+						<input type="text" :name="`system.resources.points.${pointKey}.label`" v-model="point.label"/>
+					</div>
+					<!-- Value -->
+					<div class="resource-value form-group stacked">
+						<label>Value</label>
+						<input type="number" :name="`system.resources.points.${pointKey}.value`" v-model="point.value"/>
+					</div>
+					<!-- Max -->
+					<div class="resource-value resource-max form-group stacked">
+						<label>Max</label>
+						<input type="number" :name="`system.resources.points.${pointKey}.max`" v-model="point.max"/>
+					</div>
+					<!-- Steps -->
+					<div class="resource-steps form-group stacked">
+						<label>Display</label>
+						<select :name="`system.resources.points.${pointKey}.showSteps`" v-model="point.showSteps">
+							<option value="false">Number</option>
+							<option value="true">Checkboxes</option>
+						</select>
+					</div>
+					<!-- Delete control -->
+					<a class="resource-control resource-delete"
+						title="Delete point"
+						data-action="deleteResource"
+						data-resource-type="points"
+						:data-key="pointKey"
+					><i class="fas fa-trash"></i></a>
+				</div>
+			</div>
+		</div>
+		<!-- RESOURCE TOGGLES -->
+		<div class="resource-type resource-toggles form-group">
+			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.toggles')}}</label>
+			<a class="resource-control resource-create"
+				title="Add toggles"
+				data-action="createResource"
+				data-resource-type="toggles"
+			><i class="fas fa-plus"></i></a>
+			<!-- Pool values -->
+			<div class="resource-values form-group stacked">
+				<div v-for="(toggle, toggleKey) in context.system.resources.toggles" :key="toggleKey" class="form-group toggles-group">
+					<!-- Label -->
+					<div class="resource-label form-group stacked">
+						<label>Label</label>
+						<input type="text" :name="`system.resources.toggles.${toggleKey}.label`" v-model="toggle.label"/>
+					</div>
+					<!-- Value -->
+					<div class="resource-value form-group stacked">
+						<label>Active</label>
+						<input type="checkbox" :name="`system.resources.toggles.${toggleKey}.value`" v-model="toggle.value" />
+					</div>
+					<!-- Delete control -->
+					<a class="resource-control resource-delete"
+						title="Delete toggle"
+						data-action="deleteResource"
+						data-resource-type="toggles"
+						:data-key="toggleKey"
+					><i class="fas fa-trash"></i></a>
+				</div>
+			</div>
+		</div>
+		<!-- RESOURCE TEXT -->
+		<div class="resource-type resource-text form-group">
+			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.text')}}</label>
+			<a class="resource-control resource-create"
+				title="Add text"
+				data-action="createResource"
+				data-resource-type="text"
+			><i class="fas fa-plus"></i></a>
+			<!-- text values -->
+			<div class="resource-values form-group stacked">
+				<div v-for="(textEntry, textKey) in context.system.resources.text" :key="textKey" class="form-group texts-group">
+					<!-- Label -->
+					<div class="resource-label form-group stacked">
+						<label>Label</label>
+						<input type="text" :name="`system.resources.text.${textKey}.label`" v-model="textEntry.label"/>
+					</div>
+					<!-- Value -->
+					<div class="resource-text form-group stacked">
+						<label>Value</label>
+						<input type="number" :name="`system.resources.text.${textKey}.value`" v-model="textEntry.value"/>
+					</div>
+					<!-- Delete control -->
+					<a class="resource-control resource-delete"
+						title="Delete text"
+						data-action="deleteResource"
+						data-resource-type="text"
+						:data-key="textKey"
+					><i class="fas fa-trash"></i></a>
+				</div>
+			</div>
+		</div>
+	</fieldset>
+</template>
+
+<script setup>
+import { inject } from 'vue';
+const props = defineProps(['context']);
+const item = inject('rawDocument');
+</script>

--- a/src/vue/components/item/talent/TalentResources.vue
+++ b/src/vue/components/item/talent/TalentResources.vue
@@ -1,142 +1,64 @@
 <template>
 	<fieldset class="resources">
 		<legend>{{ context.systemFields.resources.label }}</legend>
-		<!-- RESOUCE POOLS -->
-		<div class="resource-type resource-pools form-group">
-			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.pools')}}</label>
-			<a class="resource-control resource-create"
-				title="Add pool"
-				data-action="createResource"
-				data-resource-type="pools"
-			><i class="fas fa-plus"></i></a>
-			<!-- Pool values -->
+		<div class="resource form-group stacked">
+			<!-- Resources -->
 			<div class="resource-values form-group stacked">
-				<div v-for="(pool, poolKey) in context.system.resources.pools" :key="poolKey" class="form-group pools-group">
-					<!-- Label -->
-					<div class="resource-label form-group stacked">
-						<label>Label</label>
-						<input type="text" :name="`system.resources.pools.${poolKey}.label`" v-model="pool.label"/>
-					</div>
-					<!-- Value -->
-					<div class="resource-value form-group stacked">
-						<label>Value</label>
-						<input type="number" :name="`system.resources.pools.${poolKey}.value.diceNum`" v-model="pool.value.diceNum"/>
-					</div>
-					<!-- Delete control -->
-					<a class="resource-control resource-delete"
-						title="Delete pool"
-						data-action="deleteResource"
-						data-resource-type="pools"
-						:data-key="poolKey"
-					><i class="fas fa-trash"></i></a>
-				</div>
-			</div>
-		</div>
-		<!-- RESOURCE POINTS -->
-		<div class="resource-type resource-points form-group">
-			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.points')}}</label>
-			<a class="resource-control resource-create"
-				title="Add points"
-				data-action="createResource"
-				data-resource-type="points"
-			><i class="fas fa-plus"></i></a>
-			<!-- Point values -->
-			<div class="resource-values form-group stacked">
-				<div v-for="(point, pointKey) in context.system.resources.points" :key="pointKey" class="form-group points-group">
-					<!-- Label -->
-					<div class="resource-label form-group stacked">
-						<label>Label</label>
-						<input type="text" :name="`system.resources.points.${pointKey}.label`" v-model="point.label"/>
-					</div>
-					<!-- Value -->
-					<div class="resource-value form-group stacked">
-						<label>Value</label>
-						<input type="number" :name="`system.resources.points.${pointKey}.value`" v-model="point.value"/>
-					</div>
-					<!-- Max -->
-					<div class="resource-value resource-max form-group stacked">
-						<label>Max</label>
-						<input type="number" :name="`system.resources.points.${pointKey}.max`" v-model="point.max"/>
-					</div>
-					<!-- Steps -->
-					<div class="resource-steps form-group stacked">
-						<label>Display</label>
-						<select :name="`system.resources.points.${pointKey}.showSteps`" v-model="point.showSteps">
-							<option value="false">Number</option>
-							<option value="true">Checkboxes</option>
+				<!-- Resource -->
+				<div v-for="(resource, resourceKey) in context.system.resources" :key="resourceKey" class="form-group stacked resources-group">
+					<!-- Type -->
+					<div class="resource-type form-group stacked">
+						<label>Type</label>
+						<select :name="`system.resources.${resourceKey}.type`" v-model="resource.type">
+							<option value="pool">Pool</option>
+							<option value="points">Points</option>
 						</select>
 					</div>
-					<!-- Delete control -->
-					<a class="resource-control resource-delete"
-						title="Delete point"
-						data-action="deleteResource"
-						data-resource-type="points"
-						:data-key="pointKey"
-					><i class="fas fa-trash"></i></a>
+					<!-- Options -->
+					<div class="resource-options form-group">
+						<!-- Label -->
+						<div class="resource-label form-group stacked">
+							<label>Label</label>
+							<input type="text" :name="`system.resources.${resourceKey}.label`" v-model="resource.label"/>
+						</div>
+						<!-- Pool -->
+						<div v-if="resource.type === 'pool'" class="resource-value form-group stacked">
+							<label>Value</label>
+							<input type="number" :name="`system.resources.${resourceKey}.pool.diceNum`" v-model="resource.pool.diceNum"/>
+						</div>
+						<!-- Value -->
+						<div v-if="resource.type === 'points'" class="resource-value form-group stacked">
+							<label>Value</label>
+							<input type="number" :name="`system.resources.${resourceKey}.points.value`" v-model="resource.points.value"/>
+						</div>
+						<!-- Max -->
+						<div v-if="resource.type === 'points'" class="resource-value resource-max form-group stacked">
+							<label>Max</label>
+							<input type="number" :name="`system.resources.${resourceKey}.points.max`" v-model="resource.points.max"/>
+						</div>
+						<!-- Steps -->
+						<div v-if="resource.type === 'points'" class="resource-steps form-group stacked">
+							<label>Display</label>
+							<select :name="`system.resources.${resourceKey}.points.showSteps`" v-model="resource.points.showSteps">
+								<option value="false">Number</option>
+								<option value="true">Checkboxes</option>
+							</select>
+						</div>
+						<!-- Delete control -->
+						<a class="resource-control resource-delete"
+							title="Delete pool"
+							data-action="deleteResource"
+							:data-key="resourceKey"
+						><i class="fas fa-trash"></i></a>
+					</div>
 				</div>
 			</div>
-		</div>
-		<!-- RESOURCE TOGGLES -->
-		<div class="resource-type resource-toggles form-group">
-			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.toggles')}}</label>
-			<a class="resource-control resource-create"
-				title="Add toggles"
+			<!-- Create resource button -->
+			<button class="resource-control resource-create"
+				type="button"
+				title="Add pool"
 				data-action="createResource"
-				data-resource-type="toggles"
-			><i class="fas fa-plus"></i></a>
-			<!-- Pool values -->
-			<div class="resource-values form-group stacked">
-				<div v-for="(toggle, toggleKey) in context.system.resources.toggles" :key="toggleKey" class="form-group toggles-group">
-					<!-- Label -->
-					<div class="resource-label form-group stacked">
-						<label>Label</label>
-						<input type="text" :name="`system.resources.toggles.${toggleKey}.label`" v-model="toggle.label"/>
-					</div>
-					<!-- Value -->
-					<div class="resource-value form-group stacked">
-						<label>Active</label>
-						<input type="checkbox" :name="`system.resources.toggles.${toggleKey}.value`" v-model="toggle.value" />
-					</div>
-					<!-- Delete control -->
-					<a class="resource-control resource-delete"
-						title="Delete toggle"
-						data-action="deleteResource"
-						data-resource-type="toggles"
-						:data-key="toggleKey"
-					><i class="fas fa-trash"></i></a>
-				</div>
-			</div>
-		</div>
-		<!-- RESOURCE TEXT -->
-		<div class="resource-type resource-text form-group">
-			<label class="resource-type-label">{{ game.i18n.localize('GRIMWILD.Resources.text')}}</label>
-			<a class="resource-control resource-create"
-				title="Add text"
-				data-action="createResource"
-				data-resource-type="text"
-			><i class="fas fa-plus"></i></a>
-			<!-- text values -->
-			<div class="resource-values form-group stacked">
-				<div v-for="(textEntry, textKey) in context.system.resources.text" :key="textKey" class="form-group texts-group">
-					<!-- Label -->
-					<div class="resource-label form-group stacked">
-						<label>Label</label>
-						<input type="text" :name="`system.resources.text.${textKey}.label`" v-model="textEntry.label"/>
-					</div>
-					<!-- Value -->
-					<div class="resource-text form-group stacked">
-						<label>Value</label>
-						<input type="number" :name="`system.resources.text.${textKey}.value`" v-model="textEntry.value"/>
-					</div>
-					<!-- Delete control -->
-					<a class="resource-control resource-delete"
-						title="Delete text"
-						data-action="deleteResource"
-						data-resource-type="text"
-						:data-key="textKey"
-					><i class="fas fa-trash"></i></a>
-				</div>
-			</div>
+			><i class="fas fa-plus"></i>Add resource</button>
 		</div>
 	</fieldset>
 </template>

--- a/src/vue/index.mjs
+++ b/src/vue/index.mjs
@@ -1,2 +1,3 @@
 // Main app.
 export { default as DocumentSheetVue } from './DocumentSheet.vue';
+export { default as ItemSheetVue } from './ItemSheet.vue';


### PR DESCRIPTION
## Talent Schema
- `notes` is intended for an additional notes area on talents, like "Spell theorems"
- `resources` are configured as an array with the following schema:
  - `type` to determine whether its a `pool` resource or `points` resource
  - `label` to give the resource a label for more context
  - `pool` to track current pool value, if pool type
  - `points` to track current numeric points value. Used for both numbers like `2/3` and checkboxes (single like with "push", or multiple like with "spells")

## Other Changes
- Added vue item sheets (currently only used for talents)
  - The `vue/` directory is currently a bit disorganized and could use a round of cleanup. Will take a pass at that early next week.
- Updated display of talents on character sheets to show their resources and to allow expanding/collapsing them on click.

## To-Do
- [ ] Add sheet actions to the character sheet to allow resources to be modified without opening the talent sheet itself
- [ ] Update roll template for talents to include the new fields

## Screenshots
![image](https://github.com/user-attachments/assets/1ff137ec-489e-4817-a1ae-ed3b249e48fd)
