### PR TITLE
Add GM Toolkit compendium

### DIFF
--- a/src/packs/gm_toolkit/Battleground_dziqdxkqsmj4DxTu.yml
+++ b/src/packs/gm_toolkit/Battleground_dziqdxkqsmj4DxTu.yml
@@ -1,0 +1,84 @@
+folder: cSF3Iw5klDLnZaJB
+name: Battleground
+_id: dziqdxkqsmj4DxTu
+pages:
+  - sort: 100000
+    name: Battleground
+    type: text
+    _id: ITxrstylX2Y4Kagu
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 40"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Make the
+        location an important, proactive part of the scene. Identify
+        environmental elements to bring into play.</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Features</strong></em></span><span
+        style="font-family:'Capito04VAR'">: Elements likely to impact, usually
+        complicating, the ongoing action. </span><span
+        style="font-family:'Capito04VARItalic'"><em>They have a strong effect on
+        vantage and difficulty.</em></span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Heavy winds, cluttered
+        warehouse, angry onlookers.</em></span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Threats</strong></em></span><span
+        style="font-family:'Capito04VAR'">: Hazards that present extra dangers.
+        They either get 2 </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> or repeat on a
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Timer}.</span></p><p><span><em>4d
+        heavy waves, 6d guard patrols, 8d artillery.</em></span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Aggressive spirits, Tornado,
+        Raging waters.</em></span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Note</strong></span><span
+        style="font-family:'Capito04VARItalic'"><em>: </em></span><span
+        style="font-family:'Capito04VAR'">Enemies gathered into a single
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Task
+        Pool} are listed with the dice in front </span><span
+        style="font-family:'Capito04VARItalic'"><em>(4d
+        Archers)</em></span><span style="font-family:'Capito04VAR'">. Challenges
+        are shown with a | after the pool </span><span
+        style="font-family:'Capito04VARItalic'"><em>(8d |
+        Dragon)</em></span><span
+        style="font-family:'Capito04VAR'">.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609473653
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!dziqdxkqsmj4DxTu.ITxrstylX2Y4Kagu'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609107710
+  modifiedTime: 1738609107710
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!dziqdxkqsmj4DxTu'
+categories: []
+

--- a/src/packs/gm_toolkit/Bridge_xEltzhhBRdgZ6FSn.yml
+++ b/src/packs/gm_toolkit/Bridge_xEltzhhBRdgZ6FSn.yml
@@ -1,0 +1,70 @@
+folder: 5YXY1yqWw7ivAdLy
+name: Bridge
+_id: xEltzhhBRdgZ6FSn
+pages:
+  - sort: 100000
+    name: Bridge
+    type: text
+    _id: OmVH2ZJVjYrs60Zg
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 34"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Resolve a problem the PCs face or use
+        exposition to connect some dots.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>You hear from above, ‘Need
+        some help down there?’ • It suddenly makes sense—the baron is a
+        vampire.</em></span></p><p></p></div></div><div class="page" title="Page
+        34"><div class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">BRIDGE </span><span
+        style="font-family:'Capito04VAR'">a scene when players are stuck, backed
+        into a corner, or a scene feels dull. It provides a quick out and moves
+        the story forward. Normally, it would feel like an unearned freebie, the
+        </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> you gain makes it a </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>fair
+        trade</strong></em></span><span style="font-family:'Capito04VAR'">.
+        Never use it when players are engaged—save it for when it's
+        needed.</span></p></div></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610236561
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!xEltzhhBRdgZ6FSn.OmVH2ZJVjYrs60Zg'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.xEltzhhBRdgZ6FSn
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121380
+  modifiedTime: 1738609121380
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!xEltzhhBRdgZ6FSn'
+categories: []
+

--- a/src/packs/gm_toolkit/Building_Challenges_sVlIpDLWqkiP4YMk.yml
+++ b/src/packs/gm_toolkit/Building_Challenges_sVlIpDLWqkiP4YMk.yml
@@ -1,0 +1,87 @@
+folder: ZYf6ozP1kinf3leD
+name: Building Challenges
+_id: sVlIpDLWqkiP4YMk
+pages:
+  - sort: 100000
+    name: Building Challenges
+    type: text
+    _id: zCs5z71bDLKeuhks
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <ol style="list-style-type:decimal"><li><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Assign a
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Task
+        Pool}<em> </em></span><span style="font-family:'Capito04VAR'">(4d, 6d,
+        8d) for its tenacity.</span></p></li><li><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Add traits
+        </strong></em></span><span style="font-family:'Capito04VAR'">(1 or 2)
+        that shape the situation. Skip the obvious (</span><span
+        style="font-family:'Capito04VARItalic'"><em>storm is
+        windy</em></span><span style="font-family:'Capito04VAR'">) and highlight
+        what matters (</span><span
+        style="font-family:'Capito04VARItalic'"><em>strong winds are
+        blinding</em></span><span style="font-family:'Capito04VAR'">). Keep them
+        brief and evocative.</span></p></li><li><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>List short, punchy
+        moves</strong> </em></span><span style="font-family:'Capito04VAR'">(2 or
+        3) with flexible interpretations. These are examples, not limits. You
+        can spend bonus
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}
+        on other moves, or trigger these when an
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move} is prompted by something else.</span></p></li><li><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Define a fail
+        state</strong></em></span><span style="font-family:'Capito04VAR'">, a
+        specific trigger that prevents that challenge from being accomplished.
+        Avoid obvious outcomes (</span><span
+        style="font-family:'Capito04VARItalic'"><em>dying in a
+        fight</em></span><span style="font-family:'Capito04VAR'">) and focus on
+        what creates tension (</span><span
+        style="font-family:'Capito04VARItalic'"><em>breaking a code of
+        honor</em></span><span style="font-family:'Capito04VAR'">). Players
+        should know the fail state unless mystery is part of the fun—and even
+        then, make it clear one is in play.</span></p></li></ol><p><span
+        style="font-family:'Capito04VAR'"><strong>Note</strong></span><span
+        style="font-family:'Capito04VARItalic'"><em>: Not all of these parts are
+        needed for a challenge.</em></span></p>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609265712
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!sVlIpDLWqkiP4YMk.zCs5z71bDLKeuhks'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609106510
+  modifiedTime: 1738609106510
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!sVlIpDLWqkiP4YMk'
+categories: []
+

--- a/src/packs/gm_toolkit/Buildup_c73WkXl7z1UfIX1I.yml
+++ b/src/packs/gm_toolkit/Buildup_c73WkXl7z1UfIX1I.yml
@@ -1,0 +1,69 @@
+folder: 5YXY1yqWw7ivAdLy
+name: Buildup
+_id: c73WkXl7z1UfIX1I
+pages:
+  - sort: 100000
+    name: Buildup
+    type: text
+    _id: Ptc789qmzQ8UXbVY
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 34"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Give spark to each PC, who give a
+        brief vignette before upcoming action.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>The dragon roars in its
+        lair. Let’s do a buildup. • What does it look like as you enter the
+        masquerade?</em></span></p></div><div class="column"><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">BUILDUP </span><span
+        style="font-family:'Capito04VAR'">to focus in tight on your PCs, and to
+        create moments that set the stage for major events. These vignettes,
+        whether a quiet campfire scene or tense moment before a battle, give
+        players a chance to add depth and feeling to their characters that might
+        get overlooked, and the "</span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>free</strong></em></span><span
+        style="font-family:'Capito04VAR'">"
+        @UUID[Compendium.grimwild.rules.JournalEntry.jfAL6eh3f03OfuY3]{Spark}
+        they gain lets them know that what's ahead is going to be a real
+        challenge.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!c73WkXl7z1UfIX1I.Ptc789qmzQ8UXbVY'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121380
+  modifiedTime: 1738609121380
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!c73WkXl7z1UfIX1I'
+

--- a/src/packs/gm_toolkit/Campaign_Pools_X69KzsjCZt8rNs4z.yml
+++ b/src/packs/gm_toolkit/Campaign_Pools_X69KzsjCZt8rNs4z.yml
@@ -1,0 +1,64 @@
+folder: 0gXyZ0gtSFja5n8A
+name: Campaign Pools
+_id: X69KzsjCZt8rNs4z
+pages:
+  - sort: 100000
+    name: Campaign Pools
+    type: text
+    _id: eexdnVVMdX0iqE0U
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 42"><div class="layoutArea"><div
+        class="column"><p><span
+        style="font-family:'Capito04VAR'">@UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Timers}
+        that pace long-term events across sessions </span><span
+        style="font-family:'Capito04VARItalic'"><em>(lunar eclipse, wyvern
+        migration)</em></span><span style="font-family:'Capito04VAR'">. They
+        work like
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.GlsmiXNCf4oZEXVU]{Faction}
+        pools but don’t require faction details. Use them to signal upcoming
+        events or remind you to reintroduce plotlines </span><span
+        style="font-family:'Capito04VARItalic'"><em>(betrayed NPC seeking
+        revenge)</em></span><span
+        style="font-family:'Capito04VAR'">.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609537839
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!X69KzsjCZt8rNs4z.eexdnVVMdX0iqE0U'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609108923
+  modifiedTime: 1738609108923
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!X69KzsjCZt8rNs4z'
+categories: []
+

--- a/src/packs/gm_toolkit/Challenges_28LI3vBzTskcrWM2.yml
+++ b/src/packs/gm_toolkit/Challenges_28LI3vBzTskcrWM2.yml
@@ -1,0 +1,51 @@
+folder: ZYf6ozP1kinf3leD
+name: Challenges
+_id: 28LI3vBzTskcrWM2
+pages:
+  - sort: 100000
+    name: Challenges
+    type: text
+    _id: OHw9EMj5ymkUqndc
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: "<div class=\"page\" title=\"Page 36\"><div class=\"layoutArea\"><div class=\"column\"><p><span style=\"font-family:'Capito04VAR'\">A framework to represent </span><span style=\"font-family:'Capito04VARItalic'\"><em><strong>tasks</strong></em></span><span style=\"font-family:'Capito04VAR'\">, </span><span style=\"font-family:'Capito04VARItalic'\"><em><strong>obstacles</strong></em></span><span style=\"font-family:'Capito04VAR'\">, </span><span style=\"font-family:'Capito04VARItalic'\"><em><strong>enemies</strong></em></span><span style=\"font-family:'Capito04VAR'\">, and </span><span style=\"font-family:'Capito04VARItalic'\"><em><strong>scenarios</strong> </em></span><span style=\"font-family:'Capito04VAR'\">that have greater tenacity and complexity than a single action can accomplish. <strong>Challenges</strong> allow you to track progress towards them, but also proactively oppose the PCs. Each has </span><span style=\"font-family:'Capito04VARItalic'\"><em><strong>2 bonus </strong></em>@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}<em> </em></span><span style=\"font-family:'Capito04VAR'\">to be spent on moves relating to it, and a</span><span style=\"font-family:'Capito04VARItalic'\"><em><strong> </strong></em> @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Task Pool} </span><span style=\"font-family:'Capito04VAR'\">to represent its tenacity or complexity. They can also have:</span></p><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\"><strong>Traits</strong>(</span><span style=\"font-family:'SegoeUIEmoji'\">✱</span><span style=\"font-family:'Capito04VAR'\">):Qualities they have with strong narrative impact, inflicting thorns, denying permissions, or changing vantage.</span></p><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\"><strong>Moves</strong> (</span><span style=\"font-family:'SegoeUIEmoji'\">◉</span><span style=\"font-family:'Capito04VAR'\">): Suggested impact moves they might make. These are examples, not limitations.</span></p><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\"><strong>Fail State</strong> (</span><span style=\"font-family:'SegoeUIEmoji'\">✘</span><span style=\"font-family:'Capito04VAR'\">): A trigger that signals the challenge failed, like a competing timer pool or a specific event. It prompts </span><span style=\"font-family:'Capito04VAR-Light-SC850'\">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.Dsh3aKJ3gboNE9Qo]{Lock It In}</span><span style=\"font-family:'Capito04VAR'\">.</span></p><p><span style=\"font-family:'Capito04VAR'\">Interpret these short, evocative phrases as fit the situation. Keep your own created challenges similarly brief and flexible. Some uses:</span></p><ul style=\"list-style-type:none\"><li><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\">Create a dangerous enemy or exceptionally tough task.</span></p></li><li><p><span style=\"font-family:'Capito04VARItalic'\"><em>Navigate a mountain pass. Fight the rogue wizard. Make the mayor pay up.</em></span></p></li><li><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\">Zoom in on pivotal moments.</span></p></li><li><p><span style=\"font-family:'Capito04VARItalic'\"><em>Disable a complex trap. Complete the ritual. Court the prince.</em></span></p></li><li><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\">Zoom out to collapse related tasks into one objective.</span></p></li><li><p><span style=\"font-family:'Capito04VARItalic'\"><em>Evade castle guards. Track down the criminals. Organize a mutiny.</em></span></p></li><li><p><span style=\"font-family:'SegoeUIEmoji'\">◆ \_</span><span style=\"font-family:'Capito04VAR'\">Turn a broad concept into an actionable objective.</span></p></li><li><p><span style=\"font-family:'Capito04VARItalic'\"><em>Restore the desecrated temple. Secure enough alliances. Atone for your sins.</em></span></p></li></ul></div></div></div>"
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609325085
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!28LI3vBzTskcrWM2.OHw9EMj5ymkUqndc'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609106510
+  modifiedTime: 1738609106510
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!28LI3vBzTskcrWM2'
+categories: []
+

--- a/src/packs/gm_toolkit/Challenges_ZYf6ozP1kinf3leD.yml
+++ b/src/packs/gm_toolkit/Challenges_ZYf6ozP1kinf3leD.yml
@@ -1,0 +1,20 @@
+name: Challenges
+sorting: a
+folder: null
+type: JournalEntry
+_id: ZYf6ozP1kinf3leD
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609106501
+  modifiedTime: 1738609106524
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!ZYf6ozP1kinf3leD'
+

--- a/src/packs/gm_toolkit/Combat_Kit_cSF3Iw5klDLnZaJB.yml
+++ b/src/packs/gm_toolkit/Combat_Kit_cSF3Iw5klDLnZaJB.yml
@@ -1,0 +1,20 @@
+name: Combat Kit
+sorting: a
+folder: null
+type: JournalEntry
+_id: cSF3Iw5klDLnZaJB
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609107703
+  modifiedTime: 1738609107725
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!cSF3Iw5klDLnZaJB'
+

--- a/src/packs/gm_toolkit/Combat_Kit_exCu1dCPh6NH7nAe.yml
+++ b/src/packs/gm_toolkit/Combat_Kit_exCu1dCPh6NH7nAe.yml
@@ -1,0 +1,66 @@
+folder: cSF3Iw5klDLnZaJB
+name: Combat Kit
+_id: exCu1dCPh6NH7nAe
+pages:
+  - sort: 100000
+    name: Combat Kit
+    type: text
+    _id: Bp63jfZi2mmgsy9s
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 40"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">GM tools to
+        create dynamic </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>antagonists</strong>
+        </em></span><span style="font-family:'Capito04VAR'">and </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>combat
+        scenarios</strong> </em></span><span
+        style="font-family:'Capito04VAR'">quickly.
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.M8cPhXO2ffJBIJTy]{Tier}
+        is an opponent's threat level.
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.D9XCxaiXxfGcjRg1]{Role}
+        is a keyword used to guide its behavior in battle to vary its tactics.
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.dziqdxkqsmj4DxTu]{Battlegrounds}
+        make the environment a proactive or obstacle-ridden part of the scene.
+        Mix these for dynamic combats.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609514889
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!exCu1dCPh6NH7nAe.Bp63jfZi2mmgsy9s'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609107710
+  modifiedTime: 1738609107710
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!exCu1dCPh6NH7nAe'
+categories: []
+

--- a/src/packs/gm_toolkit/Combat_Rulings_QpdFqJf6v2VoRSeR.yml
+++ b/src/packs/gm_toolkit/Combat_Rulings_QpdFqJf6v2VoRSeR.yml
@@ -1,0 +1,100 @@
+folder: 7rNlh42HUUDEXQ9f
+name: Combat Rulings
+_id: QpdFqJf6v2VoRSeR
+pages:
+  - sort: 100000
+    name: Combat Rulings
+    type: text
+    _id: hgHMaKFTNYHU4F2u
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 41"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">You map the
+        fiction to the rules just like any scene, making rulings to fill in
+        gaps. However, in combat you'll often see the same scenarios come up, so
+        for the sake of consistency, some common rulings:</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Movement</strong>: Moving
+        usually accompanies another action—the goal isn't just to get somewhere,
+        but to get there and do something. If an interesting obstacle blocks the
+        way, it needs an
+        @UUID[Compendium.grimwild.rules.JournalEntry.pmTv1Nbggk6ql92W]{Action
+        Roll}.</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Weapons</strong>: Compare the
+        weapons in play and use common sense to resolve any issues. Most weapons
+        are evenly matched; the roll only shifts if there's a clear
+        imbalance.</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Melee combat</strong>: Most
+        melee attacks use Brawn, while light, fast weapons rely on Agility.
+        Dirty tricks call for Wits, but rarely work more than
+        once.</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Ranged combat</strong>:
+        Precision attacks roll Agility, while thrown weapons use Brawn or
+        Agility based on weight and range. Charging an enemy with ranged weapons
+        is reckless, adding +1t or requiring a separate action to close the
+        gap.</span></p><p><span style="font-family:'Capito04VAR'"><strong>Ranged
+        and Casters vs. Melee</strong>: Spellcasting and precise ranged attacks
+        demand focus, which is tough with nearby threats. Inflict +1t to these
+        rolls when under immediate danger.</span></p><p><span
+        style="font-family:'Capito04VAR'">@UUID[Compendium.grimwild.rules.JournalEntry.FCERIjA706QgIWIJ]{Defense
+        Rolls}: The GM selects the stat to test. Melee attacks are dodged with
+        Agility, blocked with Brawn (using armor or shields), anticipated with
+        Wits, or keeping your nerve with Presence.</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Armor</strong>: Armor and
+        shields are represented by talents like Bulwark. Otherwise, they are
+        @UUID[Compendium.grimwild.rules.JournalEntry.uLhjdcEsx67R7ADM]{Vantage}
+        and </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.rules.JournalEntry.l1bIcnawFgjunvcF]{Set
+        Dressing}<em> </em></span><span style="font-family:'Capito04VAR'">for
+        defense rolls.</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Vulnerabilities</strong>:
+        Exploiting a vulnerability can lower
+        @UUID[Compendium.grimwild.rules.JournalEntry.CKZHOS0pAZTYwZQ9]{Thorns},
+        drop 1 before rolling a
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Pool}, or
+        even bypass the need for a roll. In some cases, finding a vulnerability
+        is required to attack at all.</span></p><p><span
+        style="font-family:'Capito04VAR'"><strong>Enemy Magic</strong>: Enemy
+        magic doesn't follow the same rules as PC magic. It manifests through GM
+        moves and is constrained only by the
+        fiction.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!QpdFqJf6v2VoRSeR.hgHMaKFTNYHU4F2u'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609117631
+  modifiedTime: 1738609117631
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!QpdFqJf6v2VoRSeR'
+

--- a/src/packs/gm_toolkit/Complicate_Things_24qGlYooVgMC1ZJu.yml
+++ b/src/packs/gm_toolkit/Complicate_Things_24qGlYooVgMC1ZJu.yml
@@ -1,0 +1,64 @@
+folder: g4byq082efDAWI1S
+name: Complicate Things
+_id: 24qGlYooVgMC1ZJu
+pages:
+  - sort: 100000
+    name: Complicate Things
+    type: text
+    _id: UE4mQwFrIw0blFdM
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 35"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Escalate a
+        situation, introduce a new problem, or pressure a bond.
+        </span></p><p><span style="font-family:'Capito04VARItalic'"><em>"A huge
+        storm rolls in." • "The guard catches sight of you and rings the alarm
+        bell."</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">COMPLICATE THINGS
+        </span><span style="font-family:'Capito04VAR'">to add twists and elevate
+        drama. Use it when things feel too stable or you want things to be even
+        more chaotic than they already are. It's also great for adding a thorn
+        to a roll by introducing sudden environmental obstacles, a great outlet
+        for extra suspense that doesn't introduce new
+        drama.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!24qGlYooVgMC1ZJu.UE4mQwFrIw0blFdM'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116086
+  modifiedTime: 1738609116086
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!24qGlYooVgMC1ZJu'
+

--- a/src/packs/gm_toolkit/Consequences_VTbLLHPvpKpeWgDR.yml
+++ b/src/packs/gm_toolkit/Consequences_VTbLLHPvpKpeWgDR.yml
@@ -1,0 +1,69 @@
+folder: WErPxEpB1oKJCPGq
+name: Consequences
+_id: VTbLLHPvpKpeWgDR
+pages:
+  - sort: 100000
+    name: Consequences
+    type: text
+    _id: UZRBBPl0350gplIN
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">What happens
+        when things go wrong—from failed rolls,
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Timers},
+        or
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Moves}. They should feel </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>hard but
+        fair</strong></em></span><span style="font-family:'Capito04VAR'">,
+        reflecting the stakes and severity of the situation. Every roll carries
+        risk; otherwise, assume success and move on.</span></p><p><span
+        style="font-family:'Capito04VAR'">Damage is a solid baseline: in a
+        fight, injuries leave you bloodied by default. Other consequences, even
+        narrative ones, should sting just as much. There’s no strict
+        formula—</span><span style="font-family:'Capito04VARItalic'"><em>it’s a
+        gut feeling</em></span><span style="font-family:'Capito04VAR'">. Let the
+        fiction guide you, and make sure to give the fiction its
+        teeth.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609779876
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!VTbLLHPvpKpeWgDR.UZRBBPl0350gplIN'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!VTbLLHPvpKpeWgDR'
+categories: []
+

--- a/src/packs/gm_toolkit/Counter_GNvl7ZFpU31MZe7z.yml
+++ b/src/packs/gm_toolkit/Counter_GNvl7ZFpU31MZe7z.yml
@@ -1,0 +1,75 @@
+folder: g4byq082efDAWI1S
+name: Counter
+_id: GNvl7ZFpU31MZe7z
+pages:
+  - sort: 100000
+    name: Counter
+    type: text
+    _id: sM67Sl8hZ5aUaB8s
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 35"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Deny things a PC can always do or
+        negate something they did.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The lich casts a quick
+        protective spell, slowing your strike." • "The queen raises a hand,
+        silencing everyone."</em></span></p></div><div
+        class="column"><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">COUNTER </span><span
+        style="font-family:'Capito04VAR'">to make the world tenaciously
+        formidable, showing that it won't just roll over. You can stop anything
+        a PC does, including successful action rolls, talents they
+        @UUID[Compendium.grimwild.rules.JournalEntry.nlCuUzlwbXjf3KNV]{Always}
+        have permission to use and extra
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r7Cy7N816z6l6Cn5]{Vigilance}.
+        If they use a talent that costs them resources, they generally don't
+        have to expend that resource (your call) but can't quickly use it again.
+        However, this can never be used to stop
+        @UUID[Compendium.grimwild.rules.JournalEntry.FCERIjA706QgIWIJ]{Defense
+        Rolls} and criticals—don't steal their thunder. Be careful, players get
+        frustrated if their victories and advantages are snatched away, so use
+        it in interesting ways and make sure the spotlight works its way back to
+        them after you take advantage of the
+        moment.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609996860
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!GNvl7ZFpU31MZe7z.sM67Sl8hZ5aUaB8s'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116086
+  modifiedTime: 1738609116086
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!GNvl7ZFpU31MZe7z'
+categories: []
+

--- a/src/packs/gm_toolkit/Cutaway_s5kx6NIL4rDoZbUM.yml
+++ b/src/packs/gm_toolkit/Cutaway_s5kx6NIL4rDoZbUM.yml
@@ -1,0 +1,65 @@
+folder: 5YXY1yqWw7ivAdLy
+name: Cutaway
+_id: s5kx6NIL4rDoZbUM
+pages:
+  - sort: 100000
+    name: Cutaway
+    type: text
+    _id: SwhTNw3LNTZW9IxM
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 34"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Narrate an info-rich scene elsewhere,
+        clueing the players in.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>In a distant village, a
+        strange sickness begins to spread. • Meanwhile, we see shadows climbing
+        the walls.</em></span></p><p></p></div><div class="column"><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">CUTAWAY </span><span
+        style="font-family:'Capito04VAR'">to clue players in on the bigger
+        picture, like a TV show scene. Show villains plotting, armies marching,
+        or even positive events. It’s more fun when players know what's
+        happening and they can steer their PCs' actions toward that drama, even
+        if their characters don't explicitly know about
+        it.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!s5kx6NIL4rDoZbUM.SwhTNw3LNTZW9IxM'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121380
+  modifiedTime: 1738609121380
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!s5kx6NIL4rDoZbUM'
+

--- a/src/packs/gm_toolkit/Entangle_VV7uXLGhN8SS7Fzs.yml
+++ b/src/packs/gm_toolkit/Entangle_VV7uXLGhN8SS7Fzs.yml
@@ -1,0 +1,75 @@
+folder: 5YXY1yqWw7ivAdLy
+name: Entangle
+_id: VV7uXLGhN8SS7Fzs
+pages:
+  - sort: 100000
+    name: Entangle
+    type: text
+    _id: mkGVE8bpEOSGO6LR
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 34"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Propose an interesting tangle to a PC.
+        Take suspense only if they accept.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>He looks at you with a
+        smirk, daring you to speak up. • The prisoner knows where your mother
+        is.</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">ENTANGLE </span><span
+        style="font-family:'Capito04VAR'">a player by proposing a juicy tangle
+        for their PC. Push </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>dilemmas</strong>
+        </em></span><span style="font-family:'Capito04VAR'">and </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>drama</strong>
+        </em></span><span style="font-family:'Capito04VAR'">towards their
+        traits, desires, bonds, and story arcs. The players pick them because
+        they want the choices that come with! When you have a great idea,
+        propose a
+        @UUID[Compendium.grimwild.rules.JournalEntry.zyFQU71s311j9gzi]{Tangle}
+        for a PC. Remember you only gain </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> if they accept, so it's up to you to
+        make the tangle irresistible. Don't push hard—this mechanic is built to
+        respect player agency. Don't punish for saying
+        no.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610266239
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!VV7uXLGhN8SS7Fzs.mkGVE8bpEOSGO6LR'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.VV7uXLGhN8SS7Fzs
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121380
+  modifiedTime: 1738609121380
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!VV7uXLGhN8SS7Fzs'
+categories: []
+

--- a/src/packs/gm_toolkit/Factions_0gXyZ0gtSFja5n8A.yml
+++ b/src/packs/gm_toolkit/Factions_0gXyZ0gtSFja5n8A.yml
@@ -1,0 +1,20 @@
+name: Factions
+sorting: a
+folder: null
+type: JournalEntry
+_id: 0gXyZ0gtSFja5n8A
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609108918
+  modifiedTime: 1738609108932
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!0gXyZ0gtSFja5n8A'
+

--- a/src/packs/gm_toolkit/Factions_GlsmiXNCf4oZEXVU.yml
+++ b/src/packs/gm_toolkit/Factions_GlsmiXNCf4oZEXVU.yml
@@ -1,0 +1,72 @@
+folder: 0gXyZ0gtSFja5n8A
+name: Factions
+_id: GlsmiXNCf4oZEXVU
+pages:
+  - sort: 100000
+    name: Factions
+    type: text
+    _id: dw67zBVsWPX0Oz2K
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 42"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Track
+        off-screen developments of major forces, creating a feeling of a living
+        world beyond the PCs. They have:</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'"><strong>Resources</strong> that show
+        their power and influence, like assets, traits, and
+        relationships.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'"><strong>Goals</strong>
+        that show their ambitions. Track them with a
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Timer}
+        called a <strong>faction pool</strong>, rolled between sessions or when
+        triggered by events in the story.</span></p><p><span
+        style="font-family:'Capito04VAR'">When a faction pool depletes, the goal
+        is either accomplished or they make their move against another faction,
+        with a
+        @UUID[Compendium.grimwild.rules.JournalEntry.P8Z5hyFjxbTzrR1I]{Story}
+        roll in their favor determining how it plays out.</span></p><p><span
+        style="font-family:'Capito04VAR'">Keep 4-6 active factions, balancing
+        major and minor ones, with competing goals. Replace factions that are no
+        longer relevant to the story.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!GlsmiXNCf4oZEXVU.dw67zBVsWPX0Oz2K'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.GlsmiXNCf4oZEXVU
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609108923
+  modifiedTime: 1738609108923
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!GlsmiXNCf4oZEXVU'
+

--- a/src/packs/gm_toolkit/Force_a_Choice_2kDKawjIklAB7LFS.yml
+++ b/src/packs/gm_toolkit/Force_a_Choice_2kDKawjIklAB7LFS.yml
@@ -1,0 +1,65 @@
+folder: g4byq082efDAWI1S
+name: Force a Choice
+_id: 2kDKawjIklAB7LFS
+pages:
+  - sort: 100000
+    name: Force a Choice
+    type: text
+    _id: xYiWtMrlzbwZHVFw
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 35"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Present tough options, with room to
+        only choose one.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"Your gold pouch and sword
+        slide towards the lava." • "Now’s the choice—the prince or the
+        marquis?"</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">FORCE A CHOICE
+        </span><span style="font-family:'Capito04VAR'">to present stark, binary
+        decisions that they can't wiggle their way out of. This move offers no
+        easy way out. When you use it, make sure to follow through without
+        softening the impact. This adds a real cinematic edge, reflecting the
+        truly difficult decisions protagonists must
+        face.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!2kDKawjIklAB7LFS.xYiWtMrlzbwZHVFw'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116086
+  modifiedTime: 1738609116086
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!2kDKawjIklAB7LFS'
+

--- a/src/packs/gm_toolkit/Foreshadow_BgDBVoiRbx5zUcoA.yml
+++ b/src/packs/gm_toolkit/Foreshadow_BgDBVoiRbx5zUcoA.yml
@@ -1,0 +1,69 @@
+folder: AlWljQLa4nCSGD2H
+name: Foreshadow
+_id: BgDBVoiRbx5zUcoA
+pages:
+  - sort: 100000
+    name: Foreshadow
+    type: text
+    _id: 48OnrMzmAhjHNjvo
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 33"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Hint at
+        trouble, sometimes with a timer pool. Prompts a later impact
+        move.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The wizard narrows his eyes
+        angrily as you enter." • "You hear hoofbeats coming, a 4d
+        timer."</em></span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><br
+        /></em></span></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">FORESHADOW </span><span
+        style="font-family:'Capito04VAR'">to signal upcoming threats and give
+        the players a chance to react. This is a great way to introduce
+        adversity when you don't have or want to spend </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'">. If they fail to deal with it or
+        ignore the danger, it prompts an
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move} and the pace of the story picks up.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610138546
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!BgDBVoiRbx5zUcoA.48OnrMzmAhjHNjvo'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119898
+  modifiedTime: 1738609119898
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!BgDBVoiRbx5zUcoA'
+categories: []
+

--- a/src/packs/gm_toolkit/GM_Moves_Lb69Qq77Xr9h8BLa.yml
+++ b/src/packs/gm_toolkit/GM_Moves_Lb69Qq77Xr9h8BLa.yml
@@ -1,0 +1,82 @@
+folder: V3M0EcoDlbmFxQPL
+name: GM Moves
+_id: Lb69Qq77Xr9h8BLa
+pages:
+  - sort: 100000
+    name: GM Moves
+    type: text
+    _id: h0l7hV2isumZbWY5
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Apparat'"><strong>GM
+        MOVES</strong></span><span style="font-family:'Capito04VAR'">. A
+        framework for good GMing practices and </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>the rules that you
+        (the GM) play by</strong></em></span><span
+        style="font-family:'Capito04VAR'">. While they can be called out
+        specifically, they typically sit in the background left unsaid, aligning
+        naturally with what you do as GM.</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.7zdZxUMRvanWB2OJ]{Story
+        Moves}<em> </em></span><span style="font-family:'Capito04VAR'">set up
+        scenes and pace the game. They hint at problems and give players a
+        chance to react to what’s happening. </span><span
+        style="font-family:'Capito04VARItalic'"><em>Make these moves as you like
+        at any time.</em></span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.meKAiEb4xEJcJ58F]{Suspense
+        Moves}<em> </em></span><span style="font-family:'Capito04VAR'">help the
+        players out in some way or escalate tension. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong
+        style="font-style:italic">Take </strong><strong>suspense when
+        used</strong></em></span><span style="font-family:'Capito04VAR'">.
+        </span><span style="font-family:'Capito04VARItalic'"><em>Make these
+        moves with good timing.</em></span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Moves}<em> </em></span><span style="font-family:'Capito04VAR'">deal
+        significant consequences, crank up the tension, and make the world feel
+        powerful. </span><span style="font-family:'Capito04VARItalic'"><em>Make
+        these moves when prompted.</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609581904
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!Lb69Qq77Xr9h8BLa.h0l7hV2isumZbWY5'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609110627
+  modifiedTime: 1738609110627
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!Lb69Qq77Xr9h8BLa'
+categories: []
+

--- a/src/packs/gm_toolkit/GM_Rules_V3M0EcoDlbmFxQPL.yml
+++ b/src/packs/gm_toolkit/GM_Rules_V3M0EcoDlbmFxQPL.yml
@@ -1,0 +1,20 @@
+name: GM Rules
+sorting: a
+folder: null
+type: JournalEntry
+_id: V3M0EcoDlbmFxQPL
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609110621
+  modifiedTime: 1738609110639
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!V3M0EcoDlbmFxQPL'
+

--- a/src/packs/gm_toolkit/GM_With_Moxie_99u2UtMwTT8eluBk.yml
+++ b/src/packs/gm_toolkit/GM_With_Moxie_99u2UtMwTT8eluBk.yml
@@ -1,0 +1,20 @@
+name: GM With Moxie
+sorting: a
+folder: null
+type: JournalEntry
+_id: 99u2UtMwTT8eluBk
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609112284
+  modifiedTime: 1738609112302
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!99u2UtMwTT8eluBk'
+

--- a/src/packs/gm_toolkit/GM_With_Moxie_G5T8lTrvGu0TC93L.yml
+++ b/src/packs/gm_toolkit/GM_With_Moxie_G5T8lTrvGu0TC93L.yml
@@ -1,0 +1,186 @@
+folder: 99u2UtMwTT8eluBk
+name: GM With Moxie
+_id: G5T8lTrvGu0TC93L
+pages:
+  - sort: 100000
+    name: GM With Moxie
+    type: text
+    _id: d2fDhZPzxNINiLGF
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 43"><div class="layoutArea"><div
+        class="column"><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Map fiction to
+        rules</strong>. </em></span><span
+        style="font-family:'Capito04VAR'">Encourage players to focus on the
+        fiction and let you handle the rules. The more narratively important
+        something is, the more mechanical weight you should give
+        it.</span></p><p><span style="font-family:'Capito04VARItalic'"><em>In a
+        game of courtly intrigue, slaying a dragon might be a montage roll for a
+        knight while an important dinner party is a complex linked challenge
+        full of dire stakes.</em></span></p><p><span
+        style="font-family:'Capito04VAR'">Get creative applying the rules,
+        mixing them up in ways not explicitly laid out. Don't be afraid to
+        tinker. </span><span style="font-family:'Capito04VARItalic'"><em>Moxie
+        </em></span><span style="font-family:'Capito04VAR'">is modular and
+        you're not going to break it. Graft on rules from other systems you
+        like, or hack </span><span
+        style="font-family:'Capito04VARItalic'"><em>Moxie </em></span><span
+        style="font-family:'Capito04VAR'">and make it your
+        own.</span></p><p><span style="font-family:'Capito04VAR'">If the rules
+        clash with what makes sense in the fiction, the fiction wins. Engage
+        with the rules quickly, resolve them, and return to the
+        story.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"What does that look like?"
+        or "Give us a quick scene."</em></span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Make rulings to fill
+        gaps</strong>. </em></span><span style="font-family:'Capito04VAR'">The
+        rules are a flexible framework and designed not to cover every detail.
+        When things fall through the cracks, try to interpret the rules' intent
+        and make a ruling that fits the moment. If it's a judgment call, tell
+        the players. If you're unsure of a rule, make a quick call now and check
+        later. When in doubt, everything can collapse down to a single story
+        roll—ask the players what they want to happen, then roll to see if
+        that's how it goes down.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Pace the game
+        cinematically</strong>. </em></span><span
+        style="font-family:'Capito04VAR'">Keep the game flowing like a
+        well-paced movie. Don't let scenes drag, </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.I4Aj7JK4MsDtnCAM]{Wrap
+        It Up} </span><span style="font-family:'Capito04VAR'">to move on to
+        something more interesting. If players don't seem keen on an upcoming
+        situation, suggest a
+        @UUID[Compendium.grimwild.rules.JournalEntry.hHy0ajd300aDAWxm]{Montage}.
+        Skip long planning phases by cutting to the action with a </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.44sUTDzcXMTbmN9i]{Set
+        the Scene} </span><span style="font-family:'Capito04VAR'">move. Reward
+        players buying into these techniques by giving them good
+        odds.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Follow the players'
+        lead</strong>. </em></span><span style="font-family:'Capito04VAR'">Keep
+        tabs on story arcs and present </span><span
+        style="font-family:'Capito04VARItalic'"><em>drama</em></span><span
+        style="font-family:'Capito04VAR'">, </span><span
+        style="font-family:'Capito04VARItalic'"><em>dilemmas</em></span><span
+        style="font-family:'Capito04VAR'">, and </span><span
+        style="font-family:'Capito04VARItalic'"><em>opportunities
+        </em></span><span style="font-family:'Capito04VAR'">related to them.
+        Follow where the characters want to go. Present interesting situations
+        related to it. When players hesitate or hit an impasse, spur them into
+        action with
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Danger
+        Timers},
+        @UUID[Compendium.grimwild.rules.JournalEntry.ZrytL42i0AD8UYXf]{Quarrels},
+        </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.VV7uXLGhN8SS7Fzs]{Entangles}</span><span
+        style="font-family:'Capito04VAR'">, or </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.xEltzhhBRdgZ6FSn]{Bridge}
+        </span><span style="font-family:'Capito04VAR'">and move
+        on.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Use the moves, or
+        don't</strong>. </em></span><span style="font-family:'Capito04VAR'">The
+        GM moves can be explicit rules, merely guidelines, or somewhere in
+        between. Some GMs will call them out by name, while others never bring
+        them up at all. Either way, as long as your GMing aligns with their
+        intent, you're doing it right.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Make moves with
+        impact</strong>. </em></span><span
+        style="font-family:'Capito04VAR'">Don't pull your
+        punches—@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Moves} are called that for a reason. They shove the story forward.
+        Players have a lot of tools at their disposal, so </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>give the world
+        teeth</strong></em></span><span style="font-family:'Capito04VAR'">. It
+        makes victory even sweeter.</span></p><p><span
+        style="font-family:'Capito04VAR'">A single impact move is flexible. You
+        can split it up into a few lesser effects </span><span
+        style="font-family:'Capito04VARItalic'"><em>(inflict a mark as you break
+        their sword)</em></span><span style="font-family:'Capito04VAR'">, hit
+        multiple PCs at once, or have a PC's action affect a totally different
+        PC, though they do get a defense roll in that case.</span></p><p><span
+        style="font-family:'Capito04VAR'">When an impact move doesn't naturally
+        flow from what's happening on-screen (</span><span
+        style="font-family:'Capito04VARItalic'"><em>common with messy
+        rolls</em></span><span style="font-family:'Capito04VAR'">), think
+        off-screen instead and complicate their lives elsewhere or take
+        </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> and hit later with better dramatic
+        timing.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Prompt player
+        narration</strong>. </em></span><span
+        style="font-family:'Capito04VAR'">After a roll, make sure the players
+        narrate how things play out—even, or </span><span
+        style="font-family:'Capito04VARItalic'"><em>especially</em></span><span
+        style="font-family:'Capito04VAR'">, on a grim. Describing failure is a
+        great way to express their character. Collaborate, but keep them
+        narrating their actions.</span></p><p><span
+        style="font-family:'Capito04VAR'">Encourage them to play off of each
+        other as well, especially with
+        @UUID[Compendium.grimwild.rules.JournalEntry.odkrgM4X8udAbLNN]{Assists}
+        and montages. Ask for reaction shots as other PCs' scenes play out to
+        gauge how they feel about it, or how their
+        @UUID[Compendium.grimwild.rules.JournalEntry.J3qpvKK8eSPQ181G]{Bond}
+        affects their reaction.</span></p><p><span
+        style="font-family:'Capito04VAR'">Most importantly, after the rules come
+        into play, get right back to narration. Make sure that the flow remains
+        </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Fiction</strong></em></span><span
+        style="font-family:'SegoeUIEmoji'"><strong>→</strong></span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Rules</strong></em></span><span
+        style="font-family:'SegoeUIEmoji'"><strong>→</strong></span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Fiction</strong></em></span><span
+        style="font-family:'Capito04VAR'">.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Be endlessly curious.
+        </em></span><span style="font-family:'Capito04VAR'">Ask provocative
+        questions about the PCs and their motivations to give players a chance
+        to expand on their characters.</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'"><em>Why in the world would you
+        do that?</em></span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VARItalic'"><em>Okay, so who'd
+        you steal that sword from?</em></span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VARItalic'"><em>So are you pissed off or
+        cool with it?</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609722972
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!G5T8lTrvGu0TC93L.d2fDhZPzxNINiLGF'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609112290
+  modifiedTime: 1738609112290
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!G5T8lTrvGu0TC93L'
+categories: []
+

--- a/src/packs/gm_toolkit/Hint_W4Hs8Ihk1StF1edv.yml
+++ b/src/packs/gm_toolkit/Hint_W4Hs8Ihk1StF1edv.yml
@@ -1,0 +1,68 @@
+folder: 8qrZk7eOvPVdUhzZ
+name: Hint
+_id: W4Hs8Ihk1StF1edv
+pages:
+  - sort: 100000
+    name: Hint
+    type: text
+    _id: Tcd4kg779oPxoUYx
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 38"><div class="layoutArea"><div
+        class="column"><p><span
+        style="font-family:'Capito04VARItalic'"><em>Tests a player's
+        skill.</em></span></p><p><span
+        style="font-variant:'small-caps'">FORESHADOW </span><span
+        style="font-family:'Capito04VAR'">with a subtle clue about a hidden
+        element. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>The player</strong>
+        </em></span><span style="font-family:'Capito04VAR'">gets a single chance
+        to interpret the situation. They're limited to just one to highlight the
+        natural response of the PC and to keep things flowing. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Player intuition
+        guides the story forward</strong>. </em></span><span
+        style="font-family:'Capito04VAR'">A correct response leads to a reveal
+        or possibly bypasses the situation entirely. </span><span
+        style="font-family:'Capito04VARItalic'"><em>That funny feeling of being
+        watched. A blood trail down a hallway.</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!W4Hs8Ihk1StF1edv.Tcd4kg779oPxoUYx'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609122965
+  modifiedTime: 1738609122965
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!W4Hs8Ihk1StF1edv'
+

--- a/src/packs/gm_toolkit/Hit_With_Impact_WErPxEpB1oKJCPGq.yml
+++ b/src/packs/gm_toolkit/Hit_With_Impact_WErPxEpB1oKJCPGq.yml
@@ -1,0 +1,20 @@
+name: Hit With Impact
+sorting: a
+folder: null
+type: JournalEntry
+_id: WErPxEpB1oKJCPGq
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113847
+  modifiedTime: 1738609113867
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!WErPxEpB1oKJCPGq'
+

--- a/src/packs/gm_toolkit/Hit__Em_Hard_JqSJSbNs9EAyNJOy.yml
+++ b/src/packs/gm_toolkit/Hit__Em_Hard_JqSJSbNs9EAyNJOy.yml
@@ -1,0 +1,65 @@
+folder: g4byq082efDAWI1S
+name: Hit 'Em Hard
+_id: JqSJSbNs9EAyNJOy
+pages:
+  - sort: 100000
+    name: Hit 'Em Hard
+    type: text
+    _id: NZQMO83b39JvyifZ
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 35"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Inflict damage on a PC, like bloodied,
+        rattled, vex, marks, or a condition.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The ceiling collapses,
+        raining rocks down on you." • "She smirks wickedly at you—take vex,
+        you’re pissed."</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">HIT 'EM HARD </span><span
+        style="font-family:'Capito04VAR'">when you need to inflict direct
+        consequences. Whether it’s damage, betrayal, or loss, this move
+        underscores the seriousness of the situation. It's a heavy reminder that
+        the world pushes back against their actions. When you use it, you should
+        be hitting them just as hard as they're trying to hit the
+        world.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!JqSJSbNs9EAyNJOy.NZQMO83b39JvyifZ'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116086
+  modifiedTime: 1738609116086
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!JqSJSbNs9EAyNJOy'
+

--- a/src/packs/gm_toolkit/Impact_Moves_3Jw6Ds3TAJYimqxj.yml
+++ b/src/packs/gm_toolkit/Impact_Moves_3Jw6Ds3TAJYimqxj.yml
@@ -1,0 +1,103 @@
+folder: g4byq082efDAWI1S
+name: Impact Moves
+_id: 3Jw6Ds3TAJYimqxj
+pages:
+  - sort: 100000
+    name: Impact Moves
+    type: text
+    _id: sQIKozYqWC5DPjVg
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 35"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VARItalic'"><em>Use
+        these moves when prompted.</em></span></p><p><span
+        style="font-family:'Apparat'"><strong>IMPACT MOVES</strong></span><span
+        style="font-family:'Capito04VAR'">. Deliver hard-hitting consequence
+        that challenge PCs and push the action forward. They require prompting,
+        so when you use them, they're sure to be justified and fair, codified
+        into the rules. They've had fair warning and should have an idea of the
+        risks. So when you make a move, make sure it has <strong>IMPACT</strong>
+        to ensure the choices leading to them matter and the world feels
+        powerful.</span></p><p><span style="font-family:'Capito04VAR'">When not
+        prompted by a roll, impact moves directly against a PC give them a
+        defense roll. Some talents also give the ability to interrupt impact
+        moves, possibly negating them. If the roll to interrupt is a messy, you
+        take suspense or keep it if you spent it to prompt the
+        move.</span></p><p></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.24qGlYooVgMC1ZJu]{Complicate
+        Things}</span><span style="font-family:'Capito04VAR'">: Escalate a
+        situation, introduce a new problem, or pressure a
+        bond.</span></p><p><span style="font-family:'Capito04VARItalic'"><em>"A
+        huge storm rolls in." • "The guard catches sight of you and rings the
+        alarm bell."</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.GNvl7ZFpU31MZe7z]{Counter}</span><span
+        style="font-family:'Capito04VAR'">: Deny things a PC can always do or
+        negate something they did.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The lich casts a quick
+        protective spell, slowing your strike." • "The queen raises a hand,
+        silencing everyone."</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.2kDKawjIklAB7LFS]{Force
+        a Choice}</span><span style="font-family:'Capito04VAR'">: Present tough
+        options, with room to only choose one.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"Your gold pouch and sword
+        slide towards the lava." • "Now’s the choice—the prince or the
+        marquis?"</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.JqSJSbNs9EAyNJOy]{Hit
+        'Em Hard}</span><span style="font-family:'Capito04VAR'">: Inflict damage
+        on a PC, like bloodied, rattled, vex, marks, or a
+        condition.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The ceiling collapses,
+        raining rocks down on you." • "She smirks wickedly at you—take vex,
+        you’re pissed."</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.Dsh3aKJ3gboNE9Qo]{Lock
+        It In}</span><span style="font-family:'Capito04VAR'">: Declare something
+        occurs, closing off immediate attempts to change it.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The thief gets away,
+        nowhere to be seen." • "The bridge behind you collapses. No going
+        back."</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610065394
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!3Jw6Ds3TAJYimqxj.sQIKozYqWC5DPjVg'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.3Jw6Ds3TAJYimqxj
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116086
+  modifiedTime: 1738609116086
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!3Jw6Ds3TAJYimqxj'
+categories: []
+

--- a/src/packs/gm_toolkit/Impact_Moves_g4byq082efDAWI1S.yml
+++ b/src/packs/gm_toolkit/Impact_Moves_g4byq082efDAWI1S.yml
@@ -1,0 +1,20 @@
+name: Impact Moves
+sorting: a
+folder: null
+type: JournalEntry
+_id: g4byq082efDAWI1S
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116078
+  modifiedTime: 1738609116101
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!g4byq082efDAWI1S'
+

--- a/src/packs/gm_toolkit/Linked_Challenges_O79qSQhIA2vaBlXW.yml
+++ b/src/packs/gm_toolkit/Linked_Challenges_O79qSQhIA2vaBlXW.yml
@@ -1,0 +1,60 @@
+folder: ZYf6ozP1kinf3leD
+name: Linked Challenges
+_id: O79qSQhIA2vaBlXW
+pages:
+  - sort: 100000
+    name: Linked Challenges
+    type: text
+    _id: anDQb27BulKC5cbl
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 37"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Linked
+        challenges are greater, more complex interactions, like epicly powerful
+        enemies or unbelievably tense social situations. Each part of the whole
+        has its own proactive presence in the scene. Give them traits that
+        prompt impact moves, triggered by the fiction (</span><span
+        style="font-family:'Capito04VARItalic'"><em>protect the
+        body</em></span><span style="font-family:'Capito04VAR'">) for dynamic
+        interactions.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!O79qSQhIA2vaBlXW.anDQb27BulKC5cbl'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609106510
+  modifiedTime: 1738609106510
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!O79qSQhIA2vaBlXW'
+

--- a/src/packs/gm_toolkit/Lock_It_In_Dsh3aKJ3gboNE9Qo.yml
+++ b/src/packs/gm_toolkit/Lock_It_In_Dsh3aKJ3gboNE9Qo.yml
@@ -1,0 +1,66 @@
+folder: g4byq082efDAWI1S
+name: Lock It In
+_id: Dsh3aKJ3gboNE9Qo
+pages:
+  - sort: 100000
+    name: Lock It In
+    type: text
+    _id: Ibu8agpTwQRib2l6
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 35"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Declare something occurs, closing off
+        immediate attempts to change it. </span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The thief gets away,
+        nowhere to be seen." • "The bridge behind you collapses. No going
+        back."</em></span></p></div><div class="column"><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">LOCK IT IN </span><span
+        style="font-family:'Capito04VAR'">to definitively close off an
+        opportunity and close out a scene that's threatening to drag on. Players
+        can be tenacious and keep trying to find some way to not be defeated.
+        This puts a definitive end to a situation. It makes follow-up attempts
+        impossible, which refocuses players' attention forward rather than
+        trying to find yet another way to attempt something they've already
+        failed at.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!Dsh3aKJ3gboNE9Qo.Ibu8agpTwQRib2l6'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609116086
+  modifiedTime: 1738609116086
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!Dsh3aKJ3gboNE9Qo'
+

--- a/src/packs/gm_toolkit/Prompt_alGNquysp2VSzQHw.yml
+++ b/src/packs/gm_toolkit/Prompt_alGNquysp2VSzQHw.yml
@@ -1,0 +1,58 @@
+folder: V3M0EcoDlbmFxQPL
+name: Prompt
+_id: alGNquysp2VSzQHw
+pages:
+  - sort: 100000
+    name: Prompt
+    type: text
+    _id: aRbQ7hWKfG1USszp
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">A trigger for
+        you to make an impact move, caused by things like grim or messy action
+        rolls, a relevant depleted pool, an unaddressed </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.BgDBVoiRbx5zUcoA]{Foreshadow}
+        </span><span style="font-family:'Capito04VAR'">move, or by spending
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609606371
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!alGNquysp2VSzQHw.aRbQ7hWKfG1USszp'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609110627
+  modifiedTime: 1738609110627
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!alGNquysp2VSzQHw'
+categories: []
+

--- a/src/packs/gm_toolkit/Question_JT7gBWoxu8GmCL2F.yml
+++ b/src/packs/gm_toolkit/Question_JT7gBWoxu8GmCL2F.yml
@@ -1,0 +1,65 @@
+folder: AlWljQLa4nCSGD2H
+name: Question
+_id: JT7gBWoxu8GmCL2F
+pages:
+  - sort: 100000
+    name: Question
+    type: text
+    _id: UDzTrpnvr9LWfLIW
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 33"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Ask
+        provocative questions to stir up drama or flesh out the
+        world.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"Why did you let them kill
+        that bandit?" • "What do you say about the queen as you sit around the
+        fire?"</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">QUESTION </span><span
+        style="font-family:'Capito04VAR'">players to help suss out what kind of
+        story they're interested in, share the creative load, and keep the story
+        fresh for yourself. Try to keep this focused on their character's
+        perspective, but feel free to dip into the meta channel here and talk
+        directly as players about what you all want to see play out in
+        game.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!JT7gBWoxu8GmCL2F.UDzTrpnvr9LWfLIW'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119898
+  modifiedTime: 1738609119898
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!JT7gBWoxu8GmCL2F'
+

--- a/src/packs/gm_toolkit/Recap_cudGLx4CTx5gFHEN.yml
+++ b/src/packs/gm_toolkit/Recap_cudGLx4CTx5gFHEN.yml
@@ -1,0 +1,69 @@
+folder: 5YXY1yqWw7ivAdLy
+name: Recap
+_id: cudGLx4CTx5gFHEN
+pages:
+  - sort: 100000
+    name: Recap
+    type: text
+    _id: 95G3hYnGBlElMO8W
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 34"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'">Summarize the last session or events
+        further in the past.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Okay, so last time you
+        wrecked that keep. • Remember when you let that bandit
+        go?</em></span></p></div><div class="column"><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">RECAP </span><span
+        style="font-family:'Capito04VAR'">at the start of each session to get
+        everyone on the same page. Hearing the last session's events builds
+        tension for what's to come. The </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> you gain can immediately push the
+        action, or hang over their heads. If a player wants to recap, skip
+        taking the suspense! You can also use a mid-session </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">RECAP </span><span
+        style="font-family:'Capito04VAR'">to remind players of a vital piece of
+        information they've forgotten.</span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610284721
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!cudGLx4CTx5gFHEN.95G3hYnGBlElMO8W'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121380
+  modifiedTime: 1738609121380
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!cudGLx4CTx5gFHEN'
+categories: []
+

--- a/src/packs/gm_toolkit/Reveal_uUQxxwutv9DQCv7D.yml
+++ b/src/packs/gm_toolkit/Reveal_uUQxxwutv9DQCv7D.yml
@@ -1,0 +1,67 @@
+folder: 8qrZk7eOvPVdUhzZ
+name: Reveal
+_id: uUQxxwutv9DQCv7D
+pages:
+  - sort: 100000
+    name: Reveal
+    type: text
+    _id: 2FihoraBCusgJKLU
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 38"><div class="layoutArea"><div
+        class="column"><p><span
+        style="font-family:'Capito04VARItalic'"><em>Tests a character's
+        skill.</em></span></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">FORESHADOW </span><span
+        style="font-family:'Capito04VAR'">with an obvious unveiling of an
+        immediately imminent threat. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>The PC</strong>
+        </em></span><span style="font-family:'Capito04VAR'">that becomes aware
+        has one chance to react before the danger strikes. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Character competence
+        guides the story forward</strong></em></span><span
+        style="font-family:'Capito04VAR'">. </span><span
+        style="font-family:'Capito04VARItalic'"><em>Spotting the assassin in
+        hiding. A whirling of gears betraying the swinging scythe trap about to
+        spring.</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!uUQxxwutv9DQCv7D.2FihoraBCusgJKLU'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609122965
+  modifiedTime: 1738609122965
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!uUQxxwutv9DQCv7D'
+

--- a/src/packs/gm_toolkit/Roles_D9XCxaiXxfGcjRg1.yml
+++ b/src/packs/gm_toolkit/Roles_D9XCxaiXxfGcjRg1.yml
@@ -1,0 +1,53 @@
+folder: cSF3Iw5klDLnZaJB
+name: Roles
+_id: D9XCxaiXxfGcjRg1
+pages:
+  - sort: 100000
+    name: Roles
+    type: text
+    _id: YO1f931wRo3cI7vs
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <p></p><table><thead><tr><td><p
+        style="font-size:2rem">Roles</p></td></tr></thead><tbody><tr><td><p><strong>Blaster</strong></p></td></tr><tr><td><p><strong>Brute</strong></p></td></tr><tr><td><p><strong>Lurker</strong></p></td></tr><tr><td><p><strong>Marksman</strong></p></td></tr><tr><td><p><strong>Overseer</strong></p></td></tr><tr><td><p><strong>Marauder</strong></p></td></tr><tr><td><p><strong>Predator</strong></p></td></tr><tr><td><p><strong>Protector</strong></p></td></tr><tr><td><p><strong>Skirmisher</strong></p></td></tr><tr><td><p><strong>Swarmer</strong></p></td></tr><tr><td><p><strong>Tactician</strong></p></td></tr><tr><td><p><strong>Trickster</strong></p></td></tr></tbody></table>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!D9XCxaiXxfGcjRg1.YO1f931wRo3cI7vs'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609107710
+  modifiedTime: 1738609107710
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!D9XCxaiXxfGcjRg1'
+

--- a/src/packs/gm_toolkit/Running_Combat_7rNlh42HUUDEXQ9f.yml
+++ b/src/packs/gm_toolkit/Running_Combat_7rNlh42HUUDEXQ9f.yml
@@ -1,0 +1,20 @@
+name: Running Combat
+sorting: a
+folder: null
+type: JournalEntry
+_id: 7rNlh42HUUDEXQ9f
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609117625
+  modifiedTime: 1738609117638
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!7rNlh42HUUDEXQ9f'
+

--- a/src/packs/gm_toolkit/Running_Combat_veHYoBb3khGbNClM.yml
+++ b/src/packs/gm_toolkit/Running_Combat_veHYoBb3khGbNClM.yml
@@ -1,0 +1,82 @@
+folder: 7rNlh42HUUDEXQ9f
+name: Running Combat
+_id: veHYoBb3khGbNClM
+pages:
+  - sort: 100000
+    name: Running Combat
+    type: text
+    _id: 2MvkhyWfOwDcbAOa
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 41"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">When a fight
+        breaks out, the action flows naturally, following the spotlight. There
+        are no specific rules that differentiate combat from any other
+        scene.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>There's no turn
+        order</strong>. </em></span><span style="font-family:'Capito04VAR'">The
+        GM describes the impending danger in the current situation and asks how
+        the PCs respond, or the PCs take action on their own. The spotlight is
+        often on the PCs, and the world's actions flow from what they do. You
+        make enemies more proactive by </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.BgDBVoiRbx5zUcoA]{Foreshadowing}
+        </span><span style="font-family:'Capito04VAR'">events and following up
+        after, or spending </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> to make
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Moves}. This results in a cinematic ebb and flow to
+        combat.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Battles occur in the
+        theater of the mind</strong></em></span><span
+        style="font-family:'Capito04VAR'">, using the group's shared imagination
+        to keep track of each participant's fictional positioning to map fiction
+        to rules. However, using </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>battlemaps</strong>
+        </em></span><span style="font-family:'Capito04VAR'">or sketching maps
+        with minis or markers to track locations during a fight works well, too.
+        This helps organize the chaotic situation, makes sure everyone gets time
+        to shine, and keeps everyone's imagination aligned. Don't get caught up
+        in detailed tracking—update the map with big
+        changes.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610115165
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!veHYoBb3khGbNClM.2MvkhyWfOwDcbAOa'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609117631
+  modifiedTime: 1738609117631
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!veHYoBb3khGbNClM'
+categories: []
+

--- a/src/packs/gm_toolkit/Set_the_Scene_44sUTDzcXMTbmN9i.yml
+++ b/src/packs/gm_toolkit/Set_the_Scene_44sUTDzcXMTbmN9i.yml
@@ -1,0 +1,70 @@
+folder: AlWljQLa4nCSGD2H
+name: Set the Scene
+_id: 44sUTDzcXMTbmN9i
+pages:
+  - sort: 100000
+    name: Set the Scene
+    type: text
+    _id: q2wMnbkD2ZdMG5lV
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 33"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Use a story
+        roll to determine how a scene starts off when it’s
+        unclear.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"All seem in festive spirits
+        in the great hall." • "All eyes coldly turn as you enter the great
+        hall."</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">SET THE SCENE </span><span
+        style="font-family:'Capito04VAR'">when you're unsure about the specifics
+        of the current fiction or want to dive straight into the action. Skip
+        detailed planning and cautious leadups that often drag gameplay down.
+        Instead, </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>jump straight into
+        the action</strong></em></span><span style="font-family:'Capito04VAR'">,
+        an in medias res shot of things already in motion! The roll sets the
+        opening mood and stakes for the scene. On a grim, it can even trigger an
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move}, kicking things off with a bang and raising tension right
+        away.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610168224
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!44sUTDzcXMTbmN9i.q2wMnbkD2ZdMG5lV'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.44sUTDzcXMTbmN9i
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119898
+  modifiedTime: 1738609119898
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!44sUTDzcXMTbmN9i'
+categories: []
+

--- a/src/packs/gm_toolkit/Setting_Risk_GK93FOTaTusCxeWy.yml
+++ b/src/packs/gm_toolkit/Setting_Risk_GK93FOTaTusCxeWy.yml
@@ -1,0 +1,64 @@
+folder: WErPxEpB1oKJCPGq
+name: Setting Risk
+_id: GK93FOTaTusCxeWy
+pages:
+  - sort: 100000
+    name: Setting Risk
+    type: text
+    _id: YB3DrSdHYuaBItET
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Framing danger
+        when it's not the default. Most rolls assume meaningful consequences.
+        Declaring <strong>high risk</strong> before a roll or situation signals
+        severe stakes—death or worse looms (</span><span
+        style="font-family:'Capito04VARItalic'"><em>an assassin
+        strikes</em></span><span style="font-family:'Capito04VAR'">).
+        <strong>Low risk</strong> shifts outcomes into lighter territory,
+        rolling for things you'd normally skip, with softer consequences
+        (</span><span style="font-family:'Capito04VARItalic'"><em>a cat's stuck
+        in a tree</em></span><span style="font-family:'Capito04VAR'">). It's a
+        tool for tone, moving between intense and light
+        play.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!GK93FOTaTusCxeWy.YB3DrSdHYuaBItET'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!GK93FOTaTusCxeWy'
+

--- a/src/packs/gm_toolkit/Splitting_It_vR77Oa1oHXHwCgR8.yml
+++ b/src/packs/gm_toolkit/Splitting_It_vR77Oa1oHXHwCgR8.yml
@@ -1,0 +1,64 @@
+folder: WErPxEpB1oKJCPGq
+name: Splitting It
+_id: vR77Oa1oHXHwCgR8
+pages:
+  - sort: 100000
+    name: Splitting It
+    type: text
+    _id: 0tsJrtTmnkhvWZmy
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Breaking big
+        consequences into smaller ones. Multiple effects can be just as
+        effective and make more sense in the situation. You might break up
+        bloo@UUID[Compendium.grimwild.rules.JournalEntry.kAGyEflDClkS3viS]{Bloodied}
+        into a few
+        @UUID[Compendium.grimwild.rules.JournalEntry.mE6axXeciWLe3skm]{Marks},
+        or rattled becoming
+        @UUID[Compendium.grimwild.rules.JournalEntry.LjjAaVn72uputf9b]{Vex} and
+        rolling a
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Pool}
+        instead. Splits make the story move in multiple
+        directions.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609856681
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!vR77Oa1oHXHwCgR8.0tsJrtTmnkhvWZmy'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!vR77Oa1oHXHwCgR8'
+categories: []
+

--- a/src/packs/gm_toolkit/Spotlight_HIO9pDCMlifR7iox.yml
+++ b/src/packs/gm_toolkit/Spotlight_HIO9pDCMlifR7iox.yml
@@ -1,0 +1,69 @@
+folder: AlWljQLa4nCSGD2H
+name: Spotlight
+_id: HIO9pDCMlifR7iox
+pages:
+  - sort: 100000
+    name: Spotlight
+    type: text
+    _id: izEjWXRODbDrCIpP
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 33"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Focus
+        attention on a PC, encouraging them to act or
+        follow-up.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"You’ve been quiet for a
+        bit—what are you up to?" • "The crone’s eyes lock onto yours, expecting
+        an answer."</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">SPOTLIGHT </span><span
+        style="font-family:'Capito04VAR'">PCs to help direct the action, ensure
+        no one is left out, and put focus where it's needed. This prompts
+        players towards action. Mix in cinematic language like </span><span
+        style="font-family:'Capito04VARItalic'"><em>"We cut to..."
+        </em></span><span style="font-family:'Capito04VAR'">or </span><span
+        style="font-family:'Capito04VARItalic'"><em>"The camera pans over to
+        show..." </em></span><span style="font-family:'Capito04VAR'">as you use
+        the "camera", your group's shared imagination space. Cut back and forth
+        between PCs and scenes to build tension and avoid focusing on a single
+        PC for too long.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610183580
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!HIO9pDCMlifR7iox.izEjWXRODbDrCIpP'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119898
+  modifiedTime: 1738609119898
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!HIO9pDCMlifR7iox'
+categories: []
+

--- a/src/packs/gm_toolkit/Spreading_It_GI7qcvtjEH2kyFS8.yml
+++ b/src/packs/gm_toolkit/Spreading_It_GI7qcvtjEH2kyFS8.yml
@@ -1,0 +1,59 @@
+folder: WErPxEpB1oKJCPGq
+name: Spreading It
+_id: GI7qcvtjEH2kyFS8
+pages:
+  - sort: 100000
+    name: Spreading It
+    type: text
+    _id: aSCtfeCczgKC4CCT
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Hitting
+        multiple PCs, nearby NPCs, or even a PC who didn't prompt the move.
+        Consequences can be identical, vary in severity, or differ entirely. If
+        a PC other than the one prompting it is hit, they get a
+        @UUID[Compendium.grimwild.rules.JournalEntry.FCERIjA706QgIWIJ]{Defense
+        Roll}. Spreads make the impact feel broader and pulling more people into
+        a dynamic scene.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609888101
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!GI7qcvtjEH2kyFS8.aSCtfeCczgKC4CCT'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!GI7qcvtjEH2kyFS8'
+categories: []
+

--- a/src/packs/gm_toolkit/Story_Moves_7zdZxUMRvanWB2OJ.yml
+++ b/src/packs/gm_toolkit/Story_Moves_7zdZxUMRvanWB2OJ.yml
@@ -1,0 +1,108 @@
+folder: AlWljQLa4nCSGD2H
+name: Story Moves
+_id: 7zdZxUMRvanWB2OJ
+pages:
+  - sort: 100000
+    name: Story Moves
+    type: text
+    _id: HtozUCvku2S65og4
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 33"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VARItalic'"><em>Use
+        these moves anytime.</em></span></p><p><span
+        style="font-family:'Capito04VAR'">Keep the narrative flowing, the action
+        engaging, and get things moving when they stall out. Player actions
+        drive the story, and story moves nudge them forward. That doesn't mean
+        the world is passive—you can describe anything happening that makes
+        sense. However, from a story and gameplay perspective, it's more
+        satisfying when the players have </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>fair
+        warning</strong> </em></span><span
+        style="font-family:'Capito04VAR'">about trouble. They know actions have
+        consequences and suspense you've earned can come back to bite them. This
+        feels fair, so outside of these you give them the initiative. It shows
+        things aren't arbitrary—</span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>the GM is also
+        playing the game, just by different rules</strong></em></span><span
+        style="font-family:'Capito04VAR'">.</span></p><p></p></div><div
+        class="column"><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.BgDBVoiRbx5zUcoA]{Foreshadow}</span><span
+        style="font-family:'Capito04VAR'">: Hint at trouble, sometimes with a
+        timer pool. Prompts a later impact move.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"The wizard narrows his eyes
+        angrily as you enter. • You hear hoofbeats coming, a 4d
+        timer."</em></span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><br /></em></span><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.JT7gBWoxu8GmCL2F]{Question}</span><span
+        style="font-family:'Capito04VAR'">: Ask provocative questions to stir up
+        drama or flesh out the world.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"Why did you let them kill
+        that bandit?" • "What do you say about the queen as you sit around the
+        fire?"</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆</span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.44sUTDzcXMTbmN9i]{Set
+        the Scene}</span><span style="font-family:'Capito04VAR'">: Use a story
+        roll to determine how a scene starts off when it’s
+        unclear.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"All seem in festive spirits
+        in the great hall." • "All eyes coldly turn as you enter the great
+        hall."</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.HIO9pDCMlifR7iox]{Spotlight}</span><span
+        style="font-family:'Capito04VAR'">: Focus attention on a PC, encouraging
+        them to act or follow-up.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"You’ve been quiet for a
+        bit—what are you up to?" • "The crone’s eyes lock onto yours, expecting
+        an answer."</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.I4Aj7JK4MsDtnCAM]{Wrap
+        It Up}</span><span style="font-family:'Capito04VAR'">: Call for a
+        montage roll or jump to a likely conclusion to a
+        scene.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"Let’s montage your escape
+        from the collapsing dungeon." • "Okay, you finish mopping up the goblin
+        rabble."</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610217851
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!7zdZxUMRvanWB2OJ.HtozUCvku2S65og4'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119898
+  modifiedTime: 1738609119898
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!7zdZxUMRvanWB2OJ'
+categories: []
+

--- a/src/packs/gm_toolkit/Story_Moves_AlWljQLa4nCSGD2H.yml
+++ b/src/packs/gm_toolkit/Story_Moves_AlWljQLa4nCSGD2H.yml
@@ -1,0 +1,20 @@
+name: Story Moves
+sorting: a
+folder: null
+type: JournalEntry
+_id: AlWljQLa4nCSGD2H
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119890
+  modifiedTime: 1738609119912
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!AlWljQLa4nCSGD2H'
+

--- a/src/packs/gm_toolkit/Strike_vUfXP0trLVE9LXWV.yml
+++ b/src/packs/gm_toolkit/Strike_vUfXP0trLVE9LXWV.yml
@@ -1,0 +1,65 @@
+folder: 8qrZk7eOvPVdUhzZ
+name: Strike
+_id: vUfXP0trLVE9LXWV
+pages:
+  - sort: 100000
+    name: Strike
+    type: text
+    _id: zyTu6VDeRsyxQQRR
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 38"><div class="layoutArea"><div
+        class="column"><p><span
+        style="font-family:'Capito04VARItalic'"><em>Tests a character's
+        defenses.</em></span></p><p><span style="font-family:'Capito04VAR'">Make
+        an impact move as the danger immediately strikes them. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>The GM</strong>
+        </em></span><span style="font-family:'Capito04VAR'">assumes the PCs were
+        not vigilant enough. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>The dangerous world
+        guides the story forward</strong></em></span><span
+        style="font-family:'Capito04VAR'">. </span><span
+        style="font-family:'Capito04VARItalic'"><em>The servant slips poison
+        into your glass. A trapdoor opens beneath
+        you.</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!vUfXP0trLVE9LXWV.zyTu6VDeRsyxQQRR'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609122965
+  modifiedTime: 1738609122965
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!vUfXP0trLVE9LXWV'
+

--- a/src/packs/gm_toolkit/Suspense_Moves_5YXY1yqWw7ivAdLy.yml
+++ b/src/packs/gm_toolkit/Suspense_Moves_5YXY1yqWw7ivAdLy.yml
@@ -1,0 +1,20 @@
+name: Suspense Moves
+sorting: a
+folder: null
+type: JournalEntry
+_id: 5YXY1yqWw7ivAdLy
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121372
+  modifiedTime: 1738609121396
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!5YXY1yqWw7ivAdLy'
+

--- a/src/packs/gm_toolkit/Suspense_Moves_meKAiEb4xEJcJ58F.yml
+++ b/src/packs/gm_toolkit/Suspense_Moves_meKAiEb4xEJcJ58F.yml
@@ -1,0 +1,106 @@
+folder: 5YXY1yqWw7ivAdLy
+name: Suspense Moves
+_id: meKAiEb4xEJcJ58F
+pages:
+  - sort: 100000
+    name: Suspense Moves
+    type: text
+    _id: MFDpOGsKqjdhewhc
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 34"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VARItalic'"><em>Use
+        these moves with cinematic timing.</em></span></p><p><span
+        style="font-family:'Capito04VAR'">Create familiar moments inspired by TV
+        shows, incentivizing you mechanically to take the time to structure the
+        story cinematically. </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>You earn
+        </strong></em>@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'">, so they reward you for handling some
+        of the tedium of GMing and remind players to stay engaged. Suspense
+        keeps the world active when things stall. When your supply of suspense
+        runs dry, you can use these to jumpstart the action again. However, use
+        them carefully—</span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>overuse</strong>
+        </em></span><span style="font-family:'Capito04VAR'">can get frustrating
+        for players, so pick your spots. But </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>timely</strong>
+        </em></span><span style="font-family:'Capito04VAR'">use makes good,
+        cinematic sense.</span></p><p></p></div></div><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.xEltzhhBRdgZ6FSn]{Bridge}</span><span
+        style="font-family:'Capito04VAR'">: Resolve a problem the PCs face or
+        use exposition to connect some dots.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>You hear from above, ‘Need
+        some help down there?’ • It suddenly makes sense—the baron is a
+        vampire.</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.c73WkXl7z1UfIX1I]{Buildup}</span><span
+        style="font-family:'Capito04VAR'">: Give spark to each PC, who give a
+        brief vignette before upcoming action.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>The dragon roars in its
+        lair. Let’s do a buildup. • What does it look like as you enter the
+        masquerade?</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.s5kx6NIL4rDoZbUM]{Cutaway}</span><span
+        style="font-family:'Capito04VAR'">: Narrate an info-rich scene
+        elsewhere, clueing the players in.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>In a distant village, a
+        strange sickness begins to spread. • Meanwhile, we see shadows climbing
+        the walls.</em></span></p><p></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.VV7uXLGhN8SS7Fzs]{Entangle}</span><span
+        style="font-family:'Capito04VAR'">: Propose an interesting tangle to a
+        PC. Take suspense only if they accept.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>He looks at you with a
+        smirk, daring you to speak up. • The prisoner knows where your mother
+        is.</em></span></p><p></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.cudGLx4CTx5gFHEN]{Recap}</span><span
+        style="font-family:'Capito04VAR'">: Summarize the last session or events
+        further in the past.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Okay, so last time you
+        wrecked that keep. • Remember when you let that bandit
+        go?</em></span></p></div></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610334612
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!meKAiEb4xEJcJ58F.MFDpOGsKqjdhewhc'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609121380
+  modifiedTime: 1738609121380
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!meKAiEb4xEJcJ58F'
+categories: []
+

--- a/src/packs/gm_toolkit/Suspense_r03swtJF4sEnG2fm.yml
+++ b/src/packs/gm_toolkit/Suspense_r03swtJF4sEnG2fm.yml
@@ -1,0 +1,66 @@
+folder: V3M0EcoDlbmFxQPL
+name: Suspense
+_id: r03swtJF4sEnG2fm
+pages:
+  - sort: 100000
+    name: Suspense
+    type: text
+    _id: Q86DJwRNC5QZIO1j
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VARItalic'"><em>Pure
+        rising tension and cinematic timing</em></span><span
+        style="font-family:'Capito04VAR'">. Gain suspense by skipping a prompted
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move} or making a
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.meKAiEb4xEJcJ58F]{Suspense
+        Move}. Spend it to prompt an impact move at any time.</span></p><p><span
+        style="font-family:'Capito04VAR'">Skipping an impact move feels like the
+        PCs got off lucky—something </span><span
+        style="font-family:'Capito04VARItalic'"><em>should </em></span><span
+        style="font-family:'Capito04VAR'">have happened, but didn't. That
+        lingering suspense builds tension, ready to strike later. Use this when
+        no immediate move feels compelling or when you want to shift focus to
+        other scenes.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609645612
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!r03swtJF4sEnG2fm.Q86DJwRNC5QZIO1j'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.r03swtJF4sEnG2fm
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609110627
+  modifiedTime: 1738609110627
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!r03swtJF4sEnG2fm'
+categories: []
+

--- a/src/packs/gm_toolkit/Taking_Suspense_2NXC731yJr86Vqty.yml
+++ b/src/packs/gm_toolkit/Taking_Suspense_2NXC731yJr86Vqty.yml
@@ -1,0 +1,56 @@
+folder: WErPxEpB1oKJCPGq
+name: Taking Suspense
+_id: 2NXC731yJr86Vqty
+pages:
+  - sort: 100000
+    name: Taking Suspense
+    type: text
+    _id: WFqI3HUVugsFGNGu
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">When nothing
+        comes to mind, skip the impact move and take </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'"> instead!</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609897913
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!2NXC731yJr86Vqty.WFqI3HUVugsFGNGu'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!2NXC731yJr86Vqty'
+categories: []
+

--- a/src/packs/gm_toolkit/Thinking_Offscreen_fAxmXNJNE9XqqMmc.yml
+++ b/src/packs/gm_toolkit/Thinking_Offscreen_fAxmXNJNE9XqqMmc.yml
@@ -1,0 +1,58 @@
+folder: WErPxEpB1oKJCPGq
+name: Thinking Offscreen
+_id: fAxmXNJNE9XqqMmc
+pages:
+  - sort: 100000
+    name: Thinking Offscreen
+    type: text
+    _id: Rl8ndBbeMqLMBOQD
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Fallout that
+        happens beyond the immediate action. Not all consequences need to occur
+        in the spotlight. Hitting elsewhere builds tension, hastens incoming
+        trouble, or creates missed opportunities. These unseen events make the
+        world feel alive, adding depth beyond the present
+        moment.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!fAxmXNJNE9XqqMmc.Rl8ndBbeMqLMBOQD'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!fAxmXNJNE9XqqMmc'
+

--- a/src/packs/gm_toolkit/Tiers_M8cPhXO2ffJBIJTy.yml
+++ b/src/packs/gm_toolkit/Tiers_M8cPhXO2ffJBIJTy.yml
@@ -1,0 +1,96 @@
+folder: cSF3Iw5klDLnZaJB
+name: Tiers
+_id: M8cPhXO2ffJBIJTy
+pages:
+  - sort: 100000
+    name: Tiers
+    type: text
+    _id: 7HfI2OyH0WPNYXh4
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <p></p><table><thead><tr><td><p
+        style="font-size:2rem">TIERS</p></td></tr></thead><tbody><tr><td><div
+        class="page" title="Page 40"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'"><strong>MOOK</strong><br
+        /></span><span style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'">Mostly just </span><span
+        style="font-family:'Capito04VARItalic'"><em>set
+        dressing</em></span><span
+        style="font-family:'Capito04VAR'">.</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'">One action roll can take out
+        several.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">Large groups can be a
+        task pool.</span></p></div></div></div></div></td></tr><tr><td><div
+        class="page" title="Page 40"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'"><strong>TOUGH</strong><br
+        /></span><span style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'">A typical, dangerous
+        enemy.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">One action roll can take
+        out one of them.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">Small groups can be a
+        task pool.</span></p></div></div></div></div></td></tr><tr><td><div
+        class="page" title="Page 40"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'"><strong>ELITE</strong><br
+        /></span><span style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'">Strong scene
+        presence.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">A 4d/6d
+        challenge.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">Often leads a group of
+        lesser enemies.</span></p></div></div></div></div></td></tr><tr><td><div
+        class="page" title="Page 40"><div class="section"><div
+        class="layoutArea"><div class="column"><p><span
+        style="font-family:'Capito04VAR'"><strong>BOSS</strong><br
+        /></span><span style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'">Commands the scene.</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'">A 6d/8d challenge or linked
+        challenge.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">Extremely
+        powerful.</span></p></div></div></div></div></td></tr></tbody></table>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!M8cPhXO2ffJBIJTy.7HfI2OyH0WPNYXh4'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609107710
+  modifiedTime: 1738609107710
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!M8cPhXO2ffJBIJTy'
+

--- a/src/packs/gm_toolkit/Using_Challenges_1vcuZybwoCLWtmM1.yml
+++ b/src/packs/gm_toolkit/Using_Challenges_1vcuZybwoCLWtmM1.yml
@@ -1,0 +1,83 @@
+folder: ZYf6ozP1kinf3leD
+name: Using Challenges
+_id: 1vcuZybwoCLWtmM1
+pages:
+  - sort: 100000
+    name: Using Challenges
+    type: text
+    _id: tVRryXfQpdkslDLd
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 36"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Challenges are
+        for moments of narrative importance. They make whatever you assign them
+        to a proactive element in the story. Use them to spotlight what's
+        happening—not because it's harder, but because it deserves proper screen
+        time and presence. Introduce challenges at times
+        like:</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">An
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move} is prompted.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>The sleeping dragon wakes
+        up. They fail to reach the pass before winter. The dying goblin blows
+        the horn.</em></span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">You </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.BgDBVoiRbx5zUcoA]{Foreshadow}
+        </span><span style="font-family:'Capito04VAR'">to give fair
+        warning.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Drumming from the deep. Wind
+        blows out the torches. There are signs of
+        battle.</em></span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">You </span><span
+        style="font-family:'Capito04VAR-Light-SC850'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.24qGlYooVgMC1ZJu]{Complicate
+        Things} </span><span style="font-family:'Capito04VAR'">without
+        warning.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Arrows whizz by, an ambush!
+        The statues spring to life. A huge storm hits the
+        ship.</em></span></p><p><span style="font-family:'SegoeUIEmoji'">◆
+        </span><span style="font-family:'Capito04VAR'">The PCs head straight
+        towards trouble on their own.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Sneak into a well-guarded
+        keep. Call out the drake. Pass through a haunted
+        forest.</em></span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609457333
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!1vcuZybwoCLWtmM1.tVRryXfQpdkslDLd'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609106510
+  modifiedTime: 1738609106510
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!1vcuZybwoCLWtmM1'
+categories: []
+

--- a/src/packs/gm_toolkit/Using_Pools_Vy78jbkDvChAznib.yml
+++ b/src/packs/gm_toolkit/Using_Pools_Vy78jbkDvChAznib.yml
@@ -1,0 +1,63 @@
+folder: WErPxEpB1oKJCPGq
+name: Using Pools
+_id: Vy78jbkDvChAznib
+pages:
+  - sort: 100000
+    name: Using Pools
+    type: text
+    _id: 0kD1zwkG1qhUaj1o
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 32"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Building
+        pressure with danger or timer
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Pools}.
+        Start or roll a pressure or timer pool as another outlet for
+        consequences, often </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>offscreen</strong></em></span><span
+        style="font-family:'Capito04VAR'">. These create looming threats and
+        situations the PCs want to avoid or mitigate. They build pressure and
+        offer a strong alternative to skipping the move and banking </span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'">.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738609915129
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!Vy78jbkDvChAznib.0kD1zwkG1qhUaj1o'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609113855
+  modifiedTime: 1738609113855
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!Vy78jbkDvChAznib'
+categories: []
+

--- a/src/packs/gm_toolkit/Vigilance_8qrZk7eOvPVdUhzZ.yml
+++ b/src/packs/gm_toolkit/Vigilance_8qrZk7eOvPVdUhzZ.yml
@@ -1,0 +1,20 @@
+name: Vigilance
+sorting: a
+folder: null
+type: JournalEntry
+_id: 8qrZk7eOvPVdUhzZ
+description: ''
+sort: 100000
+color: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609122957
+  modifiedTime: 1738609122977
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!folders!8qrZk7eOvPVdUhzZ'
+

--- a/src/packs/gm_toolkit/Vigilance_r7Cy7N816z6l6Cn5.yml
+++ b/src/packs/gm_toolkit/Vigilance_r7Cy7N816z6l6Cn5.yml
@@ -1,0 +1,125 @@
+folder: 8qrZk7eOvPVdUhzZ
+name: Vigilance
+_id: r7Cy7N816z6l6Cn5
+pages:
+  - sort: 100000
+    name: Vigilance
+    type: text
+    _id: U2FvHvrkX6TQMvXD
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 38"><div class="layoutArea"><div
+        class="column"><p><span
+        style="font-family:'Apparat'"><strong>VIGILANCE</strong></span><span
+        style="font-family:'Capito04VAR'">. The assumed alertness of the PCs,
+        avoiding overly cautious gameplay to keep the focus on the
+        action.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em><strong>PCs are always
+        considered to be as vigilant as their vantage allows</strong>
+        </em></span><span style="font-family:'Capito04VAR'">when dealing with
+        hidden dangers like </span><span
+        style="font-family:'Capito04VARItalic'"><em>traps</em></span><span
+        style="font-family:'Capito04VAR'">, </span><span
+        style="font-family:'Capito04VARItalic'"><em>lies</em></span><span
+        style="font-family:'Capito04VAR'">, or </span><span
+        style="font-family:'Capito04VARItalic'"><em>secret
+        doors</em></span><span style="font-family:'Capito04VAR'">. However, this
+        doesn't mean they are always aware of hidden threats. Instead, the GM
+        uses a </span><span style="font-family:'Capito04VARItalic'"><em>gut
+        feeling </em></span><span style="font-family:'Capito04VAR'">to decide
+        how much the PC perceives based on their vantage and the type of tension
+        the GM wants to build.</span></p><p><span
+        style="font-family:'Capito04VAR'">Each of the three levels of vigilance
+        creates a different dynamic in the scene, a different view of PC
+        competence and the danger of the world. These three levels are:
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.W4Hs8Ihk1StF1edv]{Hint},
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.uUQxxwutv9DQCv7D]{Reveal},
+        and
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.vUfXP0trLVE9LXWV]{Strike}.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Against a prowling panther,
+        it's most likely that a farmer gets a <strong>hint</strong>, a hunter
+        gets a <strong>reveal</strong>, and a scholar takes a
+        <strong>strike</strong>. You can always mix it up, though, and give just
+        the scholar the <strong>reveal</strong>, putting them out of their
+        element.</em></span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>Against a duke lying about
+        their lineage, a priest gets a <strong>hint</strong>, another noble gets
+        a <strong>reveal</strong>, and a commoner takes a
+        <strong>strike</strong>. You can always mix it up, though, and give the
+        commoner a <strong>hint</strong>, knowing just the right random
+        tidbit.</em></span></p><p></p><hr /></div><div class="column"><p><span
+        style="font-family:'Capito04'"><strong>VIGILANCE
+        EXAMPLES</strong></span></p><p><span
+        style="font-family:'Capito04VAR'">Below are some ways that a danger can
+        manifest as hints, reveals, or
+        strikes.</span></p><p></p><table><thead><tr><td><p><strong>DANGER</strong></p></td><td><p><strong>HINT</strong></p></td><td><p><strong>REVEAL</strong></p></td><td><p><strong>STRIKE</strong></p></td></tr></thead><tbody><tr><td><p><em>Poisoned
+        dart trap</em></p></td><td><p>Floor creaks
+        unnaturally</p></td><td><p>Dartgun in wall spotted</p></td><td><p>Darts
+        fly from the walls</p></td></tr><tr><td><p><em>Flammable gas
+        trap</em></p></td><td><p>Faint smell lingers</p></td><td><p>Bit of gas
+        ignites</p></td><td><p>Area engulfed in
+        flames</p></td></tr><tr><td><p><em>Political
+        intrigue</em></p></td><td><p>Inconsistencies in
+        letter</p></td><td><p>Wax seal is clearly fake</p></td><td><p>Forgery
+        leads to crisis</p></td></tr><tr><td><p><em>Hidden
+        malice</em></p></td><td><p>Suspicious glances</p></td><td><p>Threatens a
+        PC</p></td><td><p>Calls the guard</p></td></tr><tr><td><p><em>Fractured
+        resolve</em></p></td><td><p>Hesistates when
+        speaking</p></td><td><p>Express doubts or fears</p></td><td><p>Act
+        against plans</p></td></tr><tr><td><p><em>Concealing
+        illusion</em></p></td><td><p>Shimmering
+        distortion</p></td><td><p>Reveals true form</p></td><td><p>Causes a
+        wrong move</p></td></tr><tr><td><p><em>Shattered
+        trust</em></p></td><td><p>Avoids eye contact</p></td><td><p>Lets
+        intentions slip</p></td><td><p>Betrays the
+        party</p></td></tr><tr><td><p><em>Crumbling
+        ceiling</em></p></td><td><p>Dust falls lightly</p></td><td><p>Cracks
+        spread visibly</p></td><td><p>Debris crashes
+        down</p></td></tr><tr><td><p><em>Swarming
+        insects</em></p></td><td><p>Animals running away</p></td><td><p>Cloud of
+        insects in the sky</p></td><td><p>Swarm descends
+        viciously</p></td></tr><tr><td><p><em>Cursed
+        relic</em></p></td><td><p>Air grows unnaturally cold</p></td><td><p>It
+        speaks your name</p></td><td><p>It curses the
+        handler</p></td></tr></tbody></table></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: 1738610398301
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
+    _key: '!journal.pages!r7Cy7N816z6l6Cn5.U2FvHvrkX6TQMvXD'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609122965
+  modifiedTime: 1738609122965
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+_key: '!journal!r7Cy7N816z6l6Cn5'
+categories: []
+

--- a/src/packs/gm_toolkit/Wrap_It_Up_I4Aj7JK4MsDtnCAM.yml
+++ b/src/packs/gm_toolkit/Wrap_It_Up_I4Aj7JK4MsDtnCAM.yml
@@ -1,0 +1,63 @@
+folder: AlWljQLa4nCSGD2H
+name: Wrap It Up
+_id: I4Aj7JK4MsDtnCAM
+pages:
+  - sort: 100000
+    name: Wrap It Up
+    type: text
+    _id: Ts3GNaASlXrS3Oy2
+    system: {}
+    title:
+      show: true
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <div class="page" title="Page 33"><div class="layoutArea"><div
+        class="column"><p><span style="font-family:'Capito04VAR'">Call for a
+        montage roll or jump to a likely conclusion to a
+        scene.</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>"Let’s montage your escape
+        from the collapsing dungeon." • "Okay, you finish mopping up the goblin
+        rabble."</em></span></p><p></p><p><span
+        style="font-family:'Capito04VAR-Light-SC850'">WRAP IT UP </span><span
+        style="font-family:'Capito04VAR'">when a scene has served its purpose,
+        grown stale, or feels like a foregone conclusion. Don't waste game time
+        on these. Closing these scenes out decisively keeps the narrative tight
+        and focuses on what's next.</span></p></div></div></div>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      Dl5Tvf37OuEHwdAh: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: grimwild
+      systemVersion: 0.1.0
+      createdTime: null
+      modifiedTime: null
+      lastModifiedBy: null
+    _key: '!journal.pages!I4Aj7JK4MsDtnCAM.Ts3GNaASlXrS3Oy2'
+sort: 0
+ownership:
+  default: 0
+  Dl5Tvf37OuEHwdAh: 3
+flags: {}
+_stats:
+  compendiumSource: JournalEntry.I4Aj7JK4MsDtnCAM
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: grimwild
+  systemVersion: 0.1.0
+  createdTime: 1738609119898
+  modifiedTime: 1738609119898
+  lastModifiedBy: Dl5Tvf37OuEHwdAh
+categories: []
+_key: '!journal!I4Aj7JK4MsDtnCAM'
+

--- a/src/packs/rules/Action_Roll_pmTv1Nbggk6ql92W.yml
+++ b/src/packs/rules/Action_Roll_pmTv1Nbggk6ql92W.yml
@@ -16,17 +16,20 @@ pages:
         <div class="page" title="Page 15"><div class="layoutArea"><div
         class="column"><p><span style="font-family:'Capito04VAR'">Roll to pull
         off something risky. State <strong>how &amp; why</strong>, clarifying
-        your intent. The GM picks the stat that matches your intentions.
-        </span></p><p></p><p><span style="font-family:'Capito04VAR'">Perfect.
-        You do it, and avoid trouble. </span></p><p><span
-        style="font-family:'Capito04VAR'">Messy. You do it, but there's trouble.
-        <em>Prompts and impact move</em>. </span></p><p><span
-        style="font-family:'Capito04VAR'">Grim. You fail, and there's trouble.
-        <em>Prompts and impact move</em>.</span></p><p></p><p><span
-        style="font-family:'Capito04VAR'">The GM makes an impact move to
-        introduce con- sequences. You don't get a defense roll against impact
-        moves prompted by your own action rolls— avoiding danger is already
-        factored into the roll.</span></p></div></div></div>
+        your intent. The GM picks the stat that matches your
+        intentions.</span></p><p></p><p><span
+        style="font-family:'Capito04VAR'">Perfect. You do it, and avoid
+        trouble.</span></p><p><span style="font-family:'Capito04VAR'">Messy. You
+        do it, but there's trouble. <em>Prompts an impact
+        move</em>.</span></p><p><span style="font-family:'Capito04VAR'">Grim.
+        You fail, and there's trouble. <em>Prompts an impact
+        move</em>.</span></p><p></p><p><span
+        style="font-family:'Capito04VAR'">The GM makes an
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move} to introduce consequences. You don't get a
+        @UUID[Compendium.grimwild.rules.JournalEntry.FCERIjA706QgIWIJ]{Defense
+        Roll} against impact moves prompted by your own action rolls— avoiding
+        danger is already factored into the roll.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -42,8 +45,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610846939
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!pmTv1Nbggk6ql92W.zoIlyaXNAHedFlaX'
 folder: 6l6pEN0IYEMpkvt3
 sort: 100000
@@ -60,6 +63,6 @@ _stats:
   createdTime: 1738366917449
   modifiedTime: 1738366917449
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!pmTv1Nbggk6ql92W'
+categories: []
 

--- a/src/packs/rules/Always_nlCuUzlwbXjf3KNV.yml
+++ b/src/packs/rules/Always_nlCuUzlwbXjf3KNV.yml
@@ -25,9 +25,9 @@ pages:
         </span><span style="font-family:'Capito04VAR-Light-SC850',
         font-style='small-caps'"><span
         style="font-family:'Capito04VAR-Light-SC850',
-        font-style='small-caps'">COUNTER </span></span><span
-        style="font-family:'Capito04VAR'">move, a strong NPC trait is in play,
-        or other extenuating circumstances arise. </span><span
+        font-style='small-caps'">@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.GNvl7ZFpU31MZe7z]{Counter}
+        </span></span><span style="font-family:'Capito04VAR'">move, a strong NPC
+        trait is in play, or other extenuating circumstances arise. </span><span
         style="font-family:'Capito04VARItalic'"><em>In short, "always" means 95%
         of the time.</em></span></p></div></div></div>
     video:
@@ -45,8 +45,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611043908
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!nlCuUzlwbXjf3KNV.ujO2iGlkpK0eQyGK'
 sort: 0
 ownership:
@@ -62,6 +62,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!nlCuUzlwbXjf3KNV'
+categories: []
 

--- a/src/packs/rules/Assist_odkrgM4X8udAbLNN.yml
+++ b/src/packs/rules/Assist_odkrgM4X8udAbLNN.yml
@@ -22,12 +22,16 @@ pages:
         narrate your contribution, using your own result and bonds as a
         guide.</span></p><p><span
         style="font-family:'Capito04VARItalic'"><em><strong>You can assist when
-        another PC's action prompts an impact move</strong></em></span><span
-        style="font-family:'Capito04VAR'">. You make a 1d defense roll for
-        them.</span></p><p><span style="font-family:'Capito04VAR'">When you
-        <strong>share the risk</strong>, you open yourself up to consequences,
-        which can prompt a more pow- erful or additional impact move, or the GM
-        can take suspense instead.</span></p></div></div></div>
+        another PC's action prompts an
+        </strong></em>@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move}</span><span style="font-family:'Capito04VAR'">. You make a 1d
+        @UUID[Compendium.grimwild.rules.JournalEntry.FCERIjA706QgIWIJ]{Defense
+        Roll} for them.</span></p><p><span
+        style="font-family:'Capito04VAR'">When you <strong>share the
+        risk</strong>, you open yourself up to consequences, which can prompt a
+        more powerful or additional impact move, or the GM can take
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}
+        instead.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -43,8 +47,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611446502
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!odkrgM4X8udAbLNN.QWuXJGv9XSzUVuRj'
 folder: p3IcETq9NG4OSRkx
 sort: 100000
@@ -61,6 +65,6 @@ _stats:
   createdTime: 1738366919492
   modifiedTime: 1738366919492
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!odkrgM4X8udAbLNN'
+categories: []
 

--- a/src/packs/rules/Background_83BZRL246W4kP7jc.yml
+++ b/src/packs/rules/Background_83BZRL246W4kP7jc.yml
@@ -15,9 +15,10 @@ pages:
       content: >-
         <div class="page" title="Page 16"><div class="layoutArea"><div
         class="column"><p><span style="font-family:'Capito04VAR'">Your heritage,
-        upbringing, and profession—the core of your vantage. You choose any two
-        that most influences who you are now. Each gives you three wises,
-        evocative key phrases that clearly expand your
+        upbringing, and profession—the core of your
+        @UUID[Compendium.grimwild.rules.JournalEntry.uLhjdcEsx67R7ADM]{Vantage}.
+        You choose any two that most influences who you are now. Each gives you
+        three wises, evocative key phrases that clearly expand your
         vantage.</span></p><p><span
         style="font-family:'Capito04VARItalic'"><em>The ragamuffin background
         means you learned a lot from the streets; without it, your upbringing is
@@ -37,8 +38,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610489990
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!83BZRL246W4kP7jc.rkqFfktACRQG1JIO'
 folder: vUGdoKGy7PZ2fdfW
 sort: 100000
@@ -55,6 +56,6 @@ _stats:
   createdTime: 1738366915122
   modifiedTime: 1738366915122
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!83BZRL246W4kP7jc'
+categories: []
 

--- a/src/packs/rules/Bonds_J3qpvKK8eSPQ181G.yml
+++ b/src/packs/rules/Bonds_J3qpvKK8eSPQ181G.yml
@@ -33,7 +33,8 @@ pages:
         style="font-family:'Capito04VARItalic'"><em>better if
         together!</em></span><span style="font-family:'Capito04VAR'">).
         </span><span style="font-family:'Capito04VARItalic'"><em><strong>The
-        other PC takes spark</strong>.</em></span></p></div></div></div>
+        other PC takes
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.jfAL6eh3f03OfuY3]{Spark}<em>.</em></span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -49,8 +50,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610517856
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!J3qpvKK8eSPQ181G.1amUh790mI7M7ffJ'
 sort: 0
 ownership:
@@ -66,6 +67,6 @@ _stats:
   createdTime: 1738366915122
   modifiedTime: 1738366915122
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!J3qpvKK8eSPQ181G'
+categories: []
 

--- a/src/packs/rules/Buffs_wGlm4Lnx2a9wQtKE.yml
+++ b/src/packs/rules/Buffs_wGlm4Lnx2a9wQtKE.yml
@@ -18,9 +18,11 @@ pages:
         class="column"><p><span style="font-family:'Capito04VAR'">Beneficial
         effects </span><span
         style="font-family:'Capito04VARItalic'"><em>(fearless, invisible)
-        </em></span><span style="font-family:'Capito04VAR'">that expand vantage,
-        ease tasks, make rolls unneces- sary, or provide outside assistance. If
-        you give a buff to an ally that persists in your absence, you can assist
+        </em></span><span style="font-family:'Capito04VAR'">that expand
+        @UUID[Compendium.grimwild.rules.JournalEntry.uLhjdcEsx67R7ADM]{Vantage},
+        ease tasks, make rolls unnecessary, or provide outside assistance. If
+        you give a buff to an ally that persists in your absence, you can
+        @UUID[Compendium.grimwild.rules.JournalEntry.odkrgM4X8udAbLNN]{Assist}
         relevant rolls without risk.</span></p></div></div></div>
     video:
       controls: true
@@ -37,8 +39,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611070988
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!wGlm4Lnx2a9wQtKE.2tZSeSez8JaX7Klz'
 sort: 0
 ownership:
@@ -54,6 +56,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!wGlm4Lnx2a9wQtKE'
+categories: []
 

--- a/src/packs/rules/Conditions_q1o6ubdVkVidryCj.yml
+++ b/src/packs/rules/Conditions_q1o6ubdVkVidryCj.yml
@@ -37,9 +37,10 @@ pages:
         style="font-family:'Capito04VAR'">It can also make an attempt
         impossible.</span></p><p><span
         style="font-family:'Capito04VAR'">Conditions clear when it makes sense,
-        like after a scene, with rest, or when a pool tracking them depletes.
-        They may also require treatment or another specific method to clear
-        them.</span></p><p><span
+        like after a scene, with rest, or when a
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Pool}
+        tracking them depletes. They may also require treatment or another
+        specific method to clear them.</span></p><p><span
         style="font-family:'Capito04VARItalic'"><em><strong>You have the final
         say on long-term and permanent conditions</strong></em></span><span
         style="font-family:'Capito04VAR'">. When you take one, work with the GM
@@ -60,8 +61,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610676273
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!q1o6ubdVkVidryCj.kS4wWtSckfZByqcB'
 sort: 0
 ownership:
@@ -77,6 +78,6 @@ _stats:
   createdTime: 1738510549034
   modifiedTime: 1738510549034
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!q1o6ubdVkVidryCj'
+categories: []
 

--- a/src/packs/rules/Defense_Roll_FCERIjA706QgIWIJ.yml
+++ b/src/packs/rules/Defense_Roll_FCERIjA706QgIWIJ.yml
@@ -21,30 +21,16 @@ pages:
         style="font-family:'Capito04VAR'">. The GM calls for the roll and picks
         a stat to test.</span></p><p></p><p><span
         style="font-family:Capito04VAR">Perfect. You avoid the
-        trouble.</span></p><p
-        style="box-sizing:border-box;user-select:text;scrollbar-width:thin;scrollbar-color:var(--color-scrollbar)
-        var(--color-scrollbar-track);margin:0.5em 0px;color:rgb(25, 24,
-        19);font-family:greycliff-cf,
-        serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;text-align:start"><span
-        style="font-family:Capito04VAR">Messy. You avoid the brunt of the
-        trouble. <em
-        style="box-sizing:border-box;user-select:text;scrollbar-width:thin;scrollbar-color:var(--color-scrollbar)
-        var(--color-scrollbar-track)">The GM lightens the
-        consequences</em>.</span></p><p
-        style="box-sizing:border-box;user-select:text;scrollbar-width:thin;scrollbar-color:var(--color-scrollbar)
-        var(--color-scrollbar-track);margin:0.5em 0px;color:rgb(25, 24,
-        19);font-family:greycliff-cf,
-        serif;font-size:14px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;-webkit-text-stroke-width:0px;white-space:normal;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;text-align:start"><span
-        style="font-family:Capito04VAR">Grim. You fail to avoid the trouble. <em
-        style="box-sizing:border-box;user-select:text;scrollbar-width:thin;scrollbar-color:var(--color-scrollbar)
-        var(--color-scrollbar-track)">The GM follows through on
-        themove</em>.</span></p><p></p><p><span
-        style="font-family:'Capito04VAR'">The GM calls for defense rolls when
-        they target you directly with an impact move. On a messy, there's still
-        some trouble, like taking lesser dam- age, losing the chance to act, or
-        being in a worse position </span><span
-        style="font-family:'Capito04VARItalic'"><em>(knocked off the
-        cliff</em></span><span style="font-family:'SegoeUIEmoji'">→</span><span
+        trouble.</span></p><p>Messy. The GM lightens the
+        consequences.</p><p>Grim. The GM follows through on the
+        move.</p><p></p><p><span style="font-family:'Capito04VAR'">The GM calls
+        for defense rolls when they target you directly with an
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move}. On a messy, there's still some trouble, like taking lesser
+        damage, losing the chance to act, or being in a worse position
+        </span><span style="font-family:'Capito04VARItalic'"><em>(knocked off
+        the cliff</em></span><span
+        style="font-family:'SegoeUIEmoji'">→</span><span
         style="font-family:'Capito04VARItalic'"><em>your sword is knocked
         off)</em></span><span
         style="font-family:'Capito04VAR'">.</span></p><p><span
@@ -73,8 +59,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610939159
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!FCERIjA706QgIWIJ.XoPCrQdCYwiA6h1c'
 folder: 6l6pEN0IYEMpkvt3
 sort: 300000
@@ -91,6 +77,6 @@ _stats:
   createdTime: 1738366917449
   modifiedTime: 1738366917449
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!FCERIjA706QgIWIJ'
+categories: []
 

--- a/src/packs/rules/Downtime_MHfXUzKNONES2zRw.yml
+++ b/src/packs/rules/Downtime_MHfXUzKNONES2zRw.yml
@@ -18,9 +18,12 @@ pages:
         class="column"><p><span style="font-family:'Capito04VAR'">Extended
         breaks </span><span style="font-family:'Capito04VARItalic'"><em>(a
         month, a season)</em></span><span style="font-family:'Capito04VAR'">.
-        Fully heal and reset per-session talents. The GM rolls faction pools.
-        After, they pick and deplete one to move the story forward. You can roll
-        a montage to achieve something non-pivotal.</span></p></div></div></div>
+        Fully heal and reset per-session talents. The GM rolls
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.GlsmiXNCf4oZEXVU]{Faction
+        Pools}. After, they pick and deplete one to move the story forward. You
+        can roll a
+        @UUID[Compendium.grimwild.rules.JournalEntry.hHy0ajd300aDAWxm]{Montage}
+        to achieve something non-pivotal.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -36,8 +39,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611269926
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!MHfXUzKNONES2zRw.4dMriwWoTLVbmWqv'
 sort: 0
 ownership:
@@ -53,6 +56,6 @@ _stats:
   createdTime: 1738510552165
   modifiedTime: 1738510552165
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!MHfXUzKNONES2zRw'
+categories: []
 

--- a/src/packs/rules/Healing_PRDMJnwI7k3SQ9Qn.yml
+++ b/src/packs/rules/Healing_PRDMJnwI7k3SQ9Qn.yml
@@ -17,10 +17,12 @@ pages:
         <div class="page" title="Page 18"><div class="layoutArea"><div
         class="column"><p><span
         style="font-family:'Capito04VARItalic'"><em><strong>When you get
-        bloodied or rattled, start a 4d pool</strong> </em></span><span
-        style="font-family:'Capito04VAR'">to track its healing. When you
-        <strong>heal</strong> harm from rest, treatment, or another source, roll
-        the pool. At 0d, clear the harm. </span><span
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.kAGyEflDClkS3viS]{Bloodied
+        or Rattled}<em><strong>, start a 4d
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Pool}<em>
+        </em></span><span style="font-family:'Capito04VAR'">to track its
+        healing. When you <strong>heal</strong> harm from rest, treatment, or
+        another source, roll the pool. At 0d, clear the harm. </span><span
         style="font-family:'Capito04VARItalic'"><em><strong>Treatment</strong>
         </em></span><span style="font-family:'Capito04VAR'">requires
         </span><span
@@ -31,8 +33,8 @@ pages:
         style="font-family:'Capito04VARItalic'"><em>training</em></span><span
         style="font-family:'Capito04VAR'">, and carries risk, and each pool can
         only benefit from treatment a single time.</span></p><p><span
-        style="font-family:'Capito04VARItalic'"><em><strong>Marks can't benefit
-        from treatment</strong></em></span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.rules.JournalEntry.mE6axXeciWLe3skm]{Marks}<em><strong>
+        can't benefit from treatment</strong></em></span><span
         style="font-family:'Capito04VAR'">. They are light enough already that
         only time heals them. They can only be cleared with rest, talents, or
         rolling.</span></p></div></div></div>
@@ -51,8 +53,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611343716
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!PRDMJnwI7k3SQ9Qn.BFMt1gP0f3urgdJO'
 sort: 0
 ownership:
@@ -68,6 +70,6 @@ _stats:
   createdTime: 1738510552165
   modifiedTime: 1738510552165
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!PRDMJnwI7k3SQ9Qn'
+categories: []
 

--- a/src/packs/rules/Interrupt_qSZOBSnVJGufxner.yml
+++ b/src/packs/rules/Interrupt_qSZOBSnVJGufxner.yml
@@ -15,10 +15,13 @@ pages:
       format: 1
       content: >-
         <div class="page" title="Page 19"><div class="layoutArea"><div
-        class="column"><p><span style="font-family:'Capito04VAR'">Make an action
-        roll to try to stop an impact move. This requires a specific talent. If
-        not already involved, you now share the risk. On a messy, the GM takes
-        or keeps suspense.</span></p></div></div></div>
+        class="column"><p><span style="font-family:'Capito04VAR'">Make an
+        @UUID[Compendium.grimwild.rules.JournalEntry.pmTv1Nbggk6ql92W]{Action
+        Roll} to try to stop an
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.3Jw6Ds3TAJYimqxj]{Impact
+        Move}. This requires a specific talent. If not already involved, you now
+        share the risk. On a messy, the GM takes or keeps
+        @UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -34,8 +37,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611112770
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!qSZOBSnVJGufxner.Q8ewzxFDoC9eZYBu'
 sort: 0
 ownership:
@@ -51,6 +54,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!qSZOBSnVJGufxner'
+categories: []
 

--- a/src/packs/rules/Level_IApWfIfwGKsmPCd2.yml
+++ b/src/packs/rules/Level_IApWfIfwGKsmPCd2.yml
@@ -17,9 +17,7 @@ pages:
         <div class="page" title="Page 19"><div class="layoutArea"><div
         class="column"><p><span style="font-family:'Capito04VAR'">A PC starts at
         level 1 and can go up to level 7. This takes 6 months of weekly play.
-        For longer play, slow down progression (</span><span
-        style="font-family:'Capito04VARItalic'"><em>below</em></span><span
-        style="font-family:'Capito04VAR'">).</span></p></div></div></div>
+        For longer play, slow down progression.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -35,8 +33,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611127801
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!IApWfIfwGKsmPCd2.jbm6BZ9eYQyWOUEa'
 sort: 0
 ownership:
@@ -52,6 +50,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!IApWfIfwGKsmPCd2'
+categories: []
 

--- a/src/packs/rules/Marks_mE6axXeciWLe3skm.yml
+++ b/src/packs/rules/Marks_mE6axXeciWLe3skm.yml
@@ -46,14 +46,17 @@ pages:
         style="font-family:'Capito04VAR-Light-SC850',
         font-style='small-caps'">PRESENCE</span></span><span
         style="font-family:'Capito04VAR'">. If both are already marked, take the
-        related <strong>harm</strong>. Note that a mark can be taken even if you
-        already have the related harm.</span></p><p><span
-        style="font-family:'Capito04VAR'">Marks are often combined with another
-        mark or other consequences when inflicted directly </span><span
+        related
+        @UUID[Compendium.grimwild.rules.JournalEntry.kAGyEflDClkS3viS]{Harm}.
+        Note that a mark can be taken even if you already have the related
+        harm.</span></p><p><span style="font-family:'Capito04VAR'">Marks are
+        often combined with another mark or other consequences when inflicted
+        directly </span><span
         style="font-family:'Capito04VARItalic'"><em>(Agility mark + thrown off
         your horse)</em></span><span style="font-family:'Capito04VAR'">. You
-        also take a mark when you <strong>push
-        yourself</strong>.</span></p></div></div></div>
+        also take a mark when you
+        @UUID[Compendium.grimwild.rules.JournalEntry.i7KRerD2wyqcWclD]{Push
+        Yourself}.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -69,8 +72,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610746406
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!mE6axXeciWLe3skm.mHg9OT7eskj9alwg'
 sort: 0
 ownership:
@@ -86,6 +89,6 @@ _stats:
   createdTime: 1738510549034
   modifiedTime: 1738510549034
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!mE6axXeciWLe3skm'
+categories: []
 

--- a/src/packs/rules/Outside_Assistance_6TBoTUBA9NuSvCCH.yml
+++ b/src/packs/rules/Outside_Assistance_6TBoTUBA9NuSvCCH.yml
@@ -14,10 +14,12 @@ pages:
       format: 1
       content: >-
         <div class="page" title="Page 14"><div class="layoutArea"><div
-        class="column"><p><span style="font-family:'Capito04VAR'">When an assist
-        or setup comes from the world, like an NPC or the environment,
-        </span><span style="font-family:'Capito04VARItalic'"><em><strong>the GM
-        rolls 1d</strong> </em></span><span style="font-family:'Capito04VAR'">to
+        class="column"><p><span style="font-family:'Capito04VAR'">When an
+        @UUID[Compendium.grimwild.rules.JournalEntry.odkrgM4X8udAbLNN]{Assist}
+        or @UUID[Compendium.grimwild.rules.JournalEntry.DcbQOR4iu3apZR17]{Setup}
+        comes from the world, like an NPC or the environment, </span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>the GM rolls
+        1d</strong> </em></span><span style="font-family:'Capito04VAR'">to
         represent it.</span></p></div></div></div>
     video:
       controls: true
@@ -34,8 +36,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611479956
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!6TBoTUBA9NuSvCCH.tztDQ25sqN8rua7L'
 folder: p3IcETq9NG4OSRkx
 sort: 400000
@@ -52,6 +54,6 @@ _stats:
   createdTime: 1738366919492
   modifiedTime: 1738366919492
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!6TBoTUBA9NuSvCCH'
+categories: []
 

--- a/src/packs/rules/Pools_5n7fkFcmZaVYZT52.yml
+++ b/src/packs/rules/Pools_5n7fkFcmZaVYZT52.yml
@@ -36,11 +36,13 @@ pages:
         a secondary effect</strong> </span><span
         style="font-family:'Capito04VARItalic'"><em>(they spill a secret, some
         mooks die)</em></span><span style="font-family:'Capito04VAR'">. If the
-        roll was only 1d, you can instead <strong>push yourself</strong> to drop
-        the last die.</span></p><p><span style="font-family:'SegoeUIEmoji'">◆
-        </span><span style="font-family:'Capito04VAR'"><strong>Drop</strong> 1d
-        from the pool before rolling it when a talent tells you to do so, you
-        have potency, or you take the </span><span
+        roll was only 1d, you can instead
+        @UUID[Compendium.grimwild.rules.JournalEntry.i7KRerD2wyqcWclD]{Push
+        Yourself} to drop the last die.</span></p><p><span
+        style="font-family:'SegoeUIEmoji'">◆ </span><span
+        style="font-family:'Capito04VAR'"><strong>Drop</strong> 1d from the pool
+        before rolling it when a talent tells you to do so, you have potency, or
+        you take the </span><span
         style="font-family:'Capito04VARItalic'"><em>greater effect
         </em></span><span style="font-family:'Capito04VAR'">critical bonus. This
         stacks.</span></p><p></p></div></div><div class="layoutArea"><div
@@ -95,8 +97,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611026583
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!5n7fkFcmZaVYZT52.yy1d6VbmnCznGkjo'
 folder: JAfDvPq9GOlzPUKM
 sort: 100000
@@ -113,6 +115,6 @@ _stats:
   createdTime: 1738366918498
   modifiedTime: 1738366918498
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!5n7fkFcmZaVYZT52'
+categories: []
 

--- a/src/packs/rules/Potency_d1U7nDi11ZnAs8rN.yml
+++ b/src/packs/rules/Potency_d1U7nDi11ZnAs8rN.yml
@@ -19,7 +19,9 @@ pages:
         pull off </span><span
         style="font-family:'Capito04VARItalic'"><em>jaw-dropping
         </em></span><span style="font-family:'Capito04VAR'">feats. When you have
-        potency on a task, you ignore thorns from difficulty (</span><span
+        potency on a task, you ignore
+        @UUID[Compendium.grimwild.rules.JournalEntry.CKZHOS0pAZTYwZQ9]{Thorns}
+        from difficulty (</span><span
         style="font-family:'Capito04VARItalic'"><em>but not from other sources
         like damage</em></span><span style="font-family:'Capito04VAR'">) and can
         attempt normally impossible (+3t) tasks. A <strong>potent feat</strong>
@@ -72,8 +74,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611150297
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!d1U7nDi11ZnAs8rN.wW9cJBFHBtpLNJzI'
 sort: 0
 ownership:
@@ -89,6 +91,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!d1U7nDi11ZnAs8rN'
+categories: []
 

--- a/src/packs/rules/Power_Pools_uOz70fAdWHwTa9mo.yml
+++ b/src/packs/rules/Power_Pools_uOz70fAdWHwTa9mo.yml
@@ -17,7 +17,8 @@ pages:
         <div class="page" title="Page 19"><div class="layoutArea"><div
         class="column"><p><span style="font-family:'Capito04VAR'">The power of
         some talents or items, rolled as part of using it or in place of a stat.
-        The same roll determines the outcome and drops dice from the pool.
+        The same roll determines the outcome and drops dice from the
+        @UUID[Compendium.grimwild.rules.JournalEntry.5n7fkFcmZaVYZT52]{Pool}.
         </span><span style="font-family:'Capito04VARItalic'"><em><strong>You can
         roll fewer dice to risk losing less</strong>. </em></span><span
         style="font-family:'NotoEmoji'">🎲 </span><span
@@ -39,8 +40,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611173098
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!uOz70fAdWHwTa9mo.3A7BIzUGAbfwdS0N'
 sort: 0
 ownership:
@@ -56,6 +57,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!uOz70fAdWHwTa9mo'
+categories: []
 

--- a/src/packs/rules/Pre_Session_Recap_SIhGcNqioDpwaJCT.yml
+++ b/src/packs/rules/Pre_Session_Recap_SIhGcNqioDpwaJCT.yml
@@ -19,7 +19,7 @@ pages:
         session (after the first), recall the previous session and share your
         PC's best moment. </span><span
         style="font-family:'Capito04VARItalic'"><em><strong>Each player takes
-        spark</strong></em></span><span
+        </strong>@UUID[Compendium.grimwild.rules.JournalEntry.jfAL6eh3f03OfuY3]{Spark}</em></span><span
         style="font-family:'Capito04VAR'">.</span></p><p><span
         style="font-family:'Capito04VAR'">When all are finished, the GM
         </span><span style="font-family:'Capito04VAR-Light-SC850',
@@ -28,8 +28,9 @@ pages:
         font-style='small-caps'">RECAPS </span></span><span
         style="font-family:'Capito04VAR'">(</span><span
         style="font-family:'Capito04VARItalic'"><em>taking
-        suspense</em></span><span style="font-family:'Capito04VAR'">) tying all
-        of these moments together into a proper "</span><span
+        </em>@UUID[Compendium.grimwild.gm_toolkit.JournalEntry.r03swtJF4sEnG2fm]{Suspense}</span><span
+        style="font-family:'Capito04VAR'">) tying all of these moments together
+        into a proper "</span><span
         style="font-family:'Capito04VARItalic'"><em>Previously
         on...</em></span><span style="font-family:'Capito04VAR'">" and starts
         the session.</span></p><p><span
@@ -51,8 +52,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610467594
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!SIhGcNqioDpwaJCT.1dgaTSoj6nuTG3kr'
 sort: 0
 ownership:
@@ -68,6 +69,6 @@ _stats:
   createdTime: 1738510545972
   modifiedTime: 1738510545972
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!SIhGcNqioDpwaJCT'
+categories: []
 

--- a/src/packs/rules/Push_Yourself_i7KRerD2wyqcWclD.yml
+++ b/src/packs/rules/Push_Yourself_i7KRerD2wyqcWclD.yml
@@ -18,8 +18,8 @@ pages:
         class="column"><p><span style="font-family:'Capito04VAR'">Expend extra
         effort to activate certain talents that require it. After using the
         talent, </span><span
-        style="font-family:'Capito04VARItalic'"><em><strong>mark a related
-        stat</strong> </em></span><span
+        style="font-family:'Capito04VARItalic'">@UUID[Compendium.grimwild.rules.JournalEntry.mE6axXeciWLe3skm]{Mark}<em>
+        <strong>a related stat</strong> </em></span><span
         style="font-family:'Capito04VAR'">(</span><span
         style="font-family:'Capito04VARItalic'"><em>your choice</em></span><span
         style="font-family:'Capito04VAR'">). Talents that require you to push
@@ -40,8 +40,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611201424
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!i7KRerD2wyqcWclD.swjZnzBxD1eMsFoJ'
 sort: 0
 ownership:
@@ -57,6 +57,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!i7KRerD2wyqcWclD'
+categories: []
 

--- a/src/packs/rules/Quarrels_ZrytL42i0AD8UYXf.yml
+++ b/src/packs/rules/Quarrels_ZrytL42i0AD8UYXf.yml
@@ -34,7 +34,7 @@ pages:
         quarrel are <strong>final</strong>—it's okay for the PC that lost to be
         bitter, but the story moves in the winner's direction. </span><span
         style="font-family:'Capito04VARItalic'"><em><strong>Both sides take
-        spark</strong>.</em></span></p></div></div></div>
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.jfAL6eh3f03OfuY3]{Spark}<em>.</em></span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -50,8 +50,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611231304
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!ZrytL42i0AD8UYXf.x2eoWeD2VOBC1kDY'
 sort: 0
 ownership:
@@ -67,6 +67,6 @@ _stats:
   createdTime: 1738510550844
   modifiedTime: 1738510550844
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!ZrytL42i0AD8UYXf'
+categories: []
 

--- a/src/packs/rules/Rest_A46cKqR8SDVPmv1y.yml
+++ b/src/packs/rules/Rest_A46cKqR8SDVPmv1y.yml
@@ -19,8 +19,10 @@ pages:
         time between significant action </span><span
         style="font-family:'Capito04VARItalic'"><em>(a night's camp, a week's
         travel)</em></span><span style="font-family:'Capito04VAR'">. Paced for
-        drama, not realism. Clear all marks and heal (roll
-        pools).</span></p></div></div></div>
+        drama, not realism. Clear all
+        @UUID[Compendium.grimwild.rules.JournalEntry.mE6axXeciWLe3skm]{Marks}
+        and @UUID[Compendium.grimwild.rules.JournalEntry.PRDMJnwI7k3SQ9Qn]{Heal}
+        (roll pools).</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -36,8 +38,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611370294
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!A46cKqR8SDVPmv1y.6CrSSyShivhGkymR'
 sort: 0
 ownership:
@@ -53,6 +55,6 @@ _stats:
   createdTime: 1738510552165
   modifiedTime: 1738510552165
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!A46cKqR8SDVPmv1y'
+categories: []
 

--- a/src/packs/rules/Set_Dressing_l1bIcnawFgjunvcF.yml
+++ b/src/packs/rules/Set_Dressing_l1bIcnawFgjunvcF.yml
@@ -19,12 +19,13 @@ pages:
         common sense details freely. Make assumptions and add </span><span
         style="font-family:'Capito04VARItalic'"><em>set dressing
         </em></span><span style="font-family:'Capito04VAR'">to scenes to play
-        off of to keep things flowing dy- namically. There’s no need to check in
+        off of to keep things flowing dynamically. There’s no need to check in
         with the GM—they’ll step in if a detail goes beyond set dressing.
         Anything that’s a </span><span
         style="font-family:'Capito04VARItalic'"><em>given </em></span><span
-        style="font-family:'Capito04VAR'">for your vantage, like knowing someone
-        or having equipment that makes sense, is set
+        style="font-family:'Capito04VAR'">for your
+        @UUID[Compendium.grimwild.rules.JournalEntry.uLhjdcEsx67R7ADM]{Vantage},
+        like knowing someone or having equipment that makes sense, is set
         dressing.</span></p></div></div></div>
     video:
       controls: true
@@ -41,8 +42,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610593360
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!l1bIcnawFgjunvcF.ix9thpsshnt9evrP'
 sort: 0
 ownership:
@@ -58,6 +59,6 @@ _stats:
   createdTime: 1738510547562
   modifiedTime: 1738510547562
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!l1bIcnawFgjunvcF'
+categories: []
 

--- a/src/packs/rules/Setup_DcbQOR4iu3apZR17.yml
+++ b/src/packs/rules/Setup_DcbQOR4iu3apZR17.yml
@@ -15,9 +15,10 @@ pages:
       content: >-
         <div class="page" title="Page 14"><div class="layoutArea"><div
         class="column"><p><span style="font-family:'Capito04VAR'">When a
-        previous action makes a follow-up more effective, you assist without
-        risk. You roll 1d as a normal assist, but don't share the risk. If it
-        was your own action, you take +1d.</span></p></div></div></div>
+        previous action makes a follow-up more effective, you
+        @UUID[Compendium.grimwild.rules.JournalEntry.odkrgM4X8udAbLNN]{Assist}
+        without risk. You roll 1d as a normal assist, but don't share the risk.
+        If it was your own action, you take +1d.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -33,8 +34,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611470327
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!DcbQOR4iu3apZR17.R0lYIzI6uaOE9gZL'
 folder: p3IcETq9NG4OSRkx
 sort: 300000
@@ -51,6 +52,6 @@ _stats:
   createdTime: 1738366919492
   modifiedTime: 1738366919492
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!DcbQOR4iu3apZR17'
+categories: []
 

--- a/src/packs/rules/Story_Arcs_Ov75OXsHOo6sUbg2.yml
+++ b/src/packs/rules/Story_Arcs_Ov75OXsHOo6sUbg2.yml
@@ -22,8 +22,9 @@ pages:
         <strong>group arc</strong> together, then a <strong>character
         arc</strong>. Pick from the examples or write your own. Keep it
         short.</span></p><p><span
-        style="font-family:'Capito04VARItalic'"><em><strong>Take spark by
-        resolving an arc</strong> </em></span><span
+        style="font-family:'Capito04VARItalic'"><em><strong>Take
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.jfAL6eh3f03OfuY3]{Spark}<em><strong>
+        by resolving an arc</strong> </em></span><span
         style="font-family:'Capito04VAR'">with a meaningful moment, </span><span
         style="font-family:'Capito04VARItalic'"><em>however big or small it
         is</em></span><span style="font-family:'Capito04VAR'">. This could mean
@@ -90,8 +91,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611393308
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!Ov75OXsHOo6sUbg2.Y1NS2LwzQ5stxuv4'
 sort: 0
 ownership:
@@ -107,6 +108,6 @@ _stats:
   createdTime: 1738510553443
   modifiedTime: 1738510553443
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!Ov75OXsHOo6sUbg2'
+categories: []
 

--- a/src/packs/rules/Story_P8Z5hyFjxbTzrR1I.yml
+++ b/src/packs/rules/Story_P8Z5hyFjxbTzrR1I.yml
@@ -22,8 +22,9 @@ pages:
         details</strong> </em></span><span
         style="font-family:'Capito04VAR'">that go beyond set dressing, creating
         new opportunities or shifting the scene in your favor. Added details
-        must fit your vantage, </span><span
-        style="font-family:'Capito04VARItalic'"><em>at least as a
+        must fit your
+        @UUID[Compendium.grimwild.rules.JournalEntry.uLhjdcEsx67R7ADM]{Vantage},
+        </span><span style="font-family:'Capito04VARItalic'"><em>at least as a
         stretch</em></span><span style="font-family:'Capito04VAR'">, or tie to a
         story arc. Example details:</span></p><p><span
         style="font-family:'SegoeUIEmoji'">◆ </span><span
@@ -34,14 +35,15 @@ pages:
         style="font-family:'SegoeUIEmoji'">◆ </span><span
         style="font-family:'Capito04VARItalic'"><em><strong>Scene</strong></em></span><span
         style="font-family:'Capito04VAR'">: NPC actions, objects,
-        atmospherics... </span></p><p><span
+        atmospherics...</span></p><p><span
         style="font-family:'Capito04VARItalic'"><em>The guard falls asleep.
         There's a secret door.</em></span></p><p><span
         style="font-family:'SegoeUIEmoji'">◆ </span><span
         style="font-family:'Capito04VARItalic'"><em><strong>Setting</strong></em></span><span
-        style="font-family:'Capito04VAR'">: History, geography, factions...
-        </span></p><p><span style="font-family:'Capito04VARItalic'"><em>There's
-        a town over those hills. The king falls ill.</em></span></p><p><span
+        style="font-family:'Capito04VAR'">: History, geography,
+        factions...</span></p><p><span
+        style="font-family:'Capito04VARItalic'"><em>There's a town over those
+        hills. The king falls ill.</em></span></p><p><span
         style="font-family:'Capito04VAR'">Added details can't override rolls or
         contradict the established story. If your detail affects another PC, get
         permission. The GM can make a story roll to see how true or beneficial
@@ -49,9 +51,10 @@ pages:
         details to keep things coherent.</span></p><p><span
         style="font-family:'Capito04VAR'">There are </span><span
         style="font-family:'Capito04VARItalic'"><em>gray zones </em></span><span
-        style="font-family:'Capito04VAR'">between set dressing, story details,
-        and details simply too impactful to add. Set boundaries with your
-        group.</span></p></div></div></div>
+        style="font-family:'Capito04VAR'">between
+        @UUID[Compendium.grimwild.rules.JournalEntry.l1bIcnawFgjunvcF]{Set
+        Dressing}, story details, and details simply too impactful to add. Set
+        boundaries with your group.</span></p></div></div></div>
     video:
       controls: true
       volume: 0.5
@@ -67,8 +70,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610643677
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!P8Z5hyFjxbTzrR1I.RBg39Sm3klbGpPEQ'
 sort: 0
 ownership:
@@ -84,6 +87,6 @@ _stats:
   createdTime: 1738510547562
   modifiedTime: 1738510547562
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!P8Z5hyFjxbTzrR1I'
+categories: []
 

--- a/src/packs/rules/Talents_iivJ5Q2aVqTgvbNq.yml
+++ b/src/packs/rules/Talents_iivJ5Q2aVqTgvbNq.yml
@@ -24,7 +24,8 @@ pages:
         with it. You gain new talents as you level, choosing from your path list
         or taking talents from other paths.</span></p><p><span
         style="font-family:'Capito04VAR'">The path name is simply a label for
-        organizing talents thematically. On its own, it doesn't expand vantage.
+        organizing talents thematically. On its own, it doesn't expand
+        @UUID[Compendium.grimwild.rules.JournalEntry.uLhjdcEsx67R7ADM]{Vantage}.
         However, talents do expand vantage. </span><span
         style="font-family:'Capito04VARItalic'"><em>Being a "fighter" doesn't
         mean anything, but the Fighting Style core talent expands your
@@ -44,8 +45,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610549266
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!iivJ5Q2aVqTgvbNq.jTpk4z7Yefi2Us4J'
 sort: 0
 ownership:
@@ -61,6 +62,6 @@ _stats:
   createdTime: 1738366915122
   modifiedTime: 1738366915122
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!iivJ5Q2aVqTgvbNq'
+categories: []
 

--- a/src/packs/rules/Teamwork_rgsG8FOLM9I27ZH1.yml
+++ b/src/packs/rules/Teamwork_rgsG8FOLM9I27ZH1.yml
@@ -22,7 +22,7 @@ pages:
         the least </span><span
         style="font-family:'Capito04VARItalic'"><em>(sneaking
         in)</em></span><span style="font-family:'Capito04VAR'">. The other PCs
-        </span>@UUID[Compendium.world.grimwild-glossary.JournalEntry.odkrgM4X8udAbLNN]{Assist}<span
+        </span>@UUID[Compendium.grimwild.rules.JournalEntry.odkrgM4X8udAbLNN]{Assist}<span
         style="font-family:'Capito04VAR'">.</span></p><p></p></div></div></div>
     video:
       controls: true
@@ -39,8 +39,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738611503503
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!rgsG8FOLM9I27ZH1.UPAi7vxXH0zaCIgG'
 folder: p3IcETq9NG4OSRkx
 sort: 500000
@@ -57,6 +57,6 @@ _stats:
   createdTime: 1738366919492
   modifiedTime: 1738366919492
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!rgsG8FOLM9I27ZH1'
+categories: []
 

--- a/src/packs/rules/Vex_LjjAaVn72uputf9b.yml
+++ b/src/packs/rules/Vex_LjjAaVn72uputf9b.yml
@@ -25,7 +25,9 @@ pages:
         style="font-family:'Capito04VAR'">. Vex is inflicted as a consequence,
         sometimes in addition to a mark or harm. </span><span
         style="font-family:'Capito04VARItalic'"><em><strong>You can also spend
-        spark to take vex in place of rattled</strong></em></span><span
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.jfAL6eh3f03OfuY3]{Spark}<strong>
+        </strong><em><strong>to take vex in place of
+        </strong></em>@UUID[Compendium.grimwild.rules.JournalEntry.kAGyEflDClkS3viS]{Rattled}</span><span
         style="font-family:'Capito04VAR'">, if it fits the situation. Vex
         prompts an immediate, instinctive response. Choose
         one:</span></p><table><tbody><tr><td><p
@@ -57,8 +59,8 @@ pages:
       systemId: grimwild
       systemVersion: 0.1.0
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1738610801049
+      lastModifiedBy: Dl5Tvf37OuEHwdAh
     _key: '!journal.pages!LjjAaVn72uputf9b.5cCe9E0toE6GOgUH'
 sort: 0
 ownership:
@@ -74,6 +76,6 @@ _stats:
   createdTime: 1738510549034
   modifiedTime: 1738510549034
   lastModifiedBy: Dl5Tvf37OuEHwdAh
-categories: []
 _key: '!journal!LjjAaVn72uputf9b'
+categories: []
 

--- a/src/styles/global/_journals.scss
+++ b/src/styles/global/_journals.scss
@@ -13,4 +13,11 @@
 
 .journal-page-content {
   font-size: 18px;
+  line-height: 25px;
+
+  table {
+    td {
+      padding: 0.5rem;
+    }
+  }
 }

--- a/src/system.yml
+++ b/src/system.yml
@@ -89,6 +89,11 @@ packs:
     type: JournalEntry
     path: packs/rules
     system: grimwild
+  - name: gm_toolkit
+    label: GM Toolkit
+    type: JournalEntry
+    path: packs/gm_toolkit
+    system: grimwild  
 packFolders: []
 
 socket: false


### PR DESCRIPTION
This commit adds a new GM Toolkit compendium with all the rules from pg 29-41 of the rulebook. It includes copious linking of terms and goes back over the Grimwild Rules compendium and adds more linking there plus some small proofreading.

Additionally, it expands the line height of journals to account for the links being larger than text and it also adds some padding to tables in journals.