### PR TITLE
Slight improve roll dialog logic

### DIFF
--- a/src/module/data/actor-character.mjs
+++ b/src/module/data/actor-character.mjs
@@ -1,6 +1,5 @@
 import GrimwildActorBase from "./base-actor.mjs";
 import { DicePoolField } from "../helpers/schema.mjs";
-import { isMentalStat, isPhysicalStat } from "../helpers/config.mjs";
 import { GrimwildRollDialog } from "../apps/roll-dialog.mjs";
 
 export default class GrimwildCharacter extends GrimwildActorBase {
@@ -231,8 +230,6 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 
 	async roll(options) {
 		const rollData = this.getRollData();
-		const markIgnored = (rollData?.isBloodied && isPhysicalStat(options.stat))
-			|| (rollData?.isRattled	&& isMentalStat(options.stat));
 
 		if (options?.stat && rollData?.stats?.[options.stat]) {
 			const rollDialog = await GrimwildRollDialog.open({
@@ -242,8 +239,7 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 					diceDefault: rollData?.stats?.[options.stat].value,
 					isBloodied: rollData?.isBloodied,
 					isRattled: rollData?.isRattled,
-					isMarked: rollData?.stats?.[options.stat].marked && !markIgnored,
-					markIgnored: markIgnored
+					isMarked: rollData?.stats?.[options.stat].marked
 				}
 			});
 


### PR DESCRIPTION
This commit moves the computation of ignoring marks into the roll dialog app as the actor itself should not be concerned with the logic of whether to show that or not.

This commit also ignores assists with no dice, and adds a default name of "Assist" to assists with no name so the chat message doesn't have an arrow pointing to nothing.