### PR TITLE
Feature/calmrush/suspensetracker

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -2,6 +2,9 @@
 GRIMWILD:
   Settings:
     Grimwild: 'Grimwild'
+    suspenseVisible:
+      name: Suspense visible to players
+      hint: Toggle this on/off to show/hide the suspense tracker for non-GMs.
   Stat:
     bra:
       long: Brawn
@@ -65,6 +68,7 @@ GRIMWILD:
     points: Points
     toggles: Toggles
     text: Text
+    suspense: Suspense
   SheetLabels:
     Actor: Grimwild Actor Sheet
     Item: Grimwild Item Sheet

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -12,8 +12,8 @@ class SuspenseTracker {
     init() {
         console.log("Suspense: initialising");
         game.settings.register("grimwild", "suspenseVisible", {
-            name: "Suspense visible to players",
-            hint: "Toggle this on/off to show/hide the suspense tracker for non-GMs",
+            name: game.i18n.localize("GRIMWILD.Settings.suspenseVisible.name"),
+            hint: game.i18n.localize("GRIMWILD.Settings.suspenseVisible.hint"),
             scope: "world",
             config: true,
             type: Boolean,
@@ -47,11 +47,12 @@ class SuspenseTracker {
             <button id="js-sus-dn">-</button>
         </div>`;
 
+        const label = game.i18n.localize("GRIMWILD.Resources.suspense");
         const susControlInnerHTML = `
         <div id="sus-control-inner">
             <div id="sus-display">
                 <div id="sus-current">${getSuspense()}</div>
-                <div id="sus-label">SUSPENSE</div>
+                <div id="sus-label">${label}</div>
             </div>
             ${isGM ? buttonHtml : ""}
         </div>`;

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -65,7 +65,7 @@ class SuspenseTracker {
         <div id="sus-control-inner">
             <div id="sus-display">
                 <div id="js-sus-current">${this.suspense}</div>
-                <div id="sus-label">suspense</div>
+                <div id="sus-label">SUSPENSE</div>
             </div>
             <div id="sus-adjust">
                 <button id="js-sus-up">+</button>

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -18,7 +18,7 @@ class SuspenseTracker {
             config: true,
             type: Boolean,
             default: true,
-            onChange: this.render
+            onChange: _ => this.render()
         });
         game.settings.register("grimwild", "suspense", {
             name: "Suspense",
@@ -30,7 +30,7 @@ class SuspenseTracker {
         });
     }
 
-    render() {
+    render(value) {
         const isGM = game.user.isGM;
         const visibleToPlayers = game.settings.get("grimwild", "suspenseVisible");
 
@@ -68,6 +68,13 @@ class SuspenseTracker {
             document.getElementById("js-sus-dn").onclick = () => {
                 setSuspense(Math.max(getSuspense() - 1, 0));
             };
+        } else if(!isNaN(value)) {
+            // flash the display to notify players that the suspense value changed
+            // a numerical value should only be passed in if triggered by the setting value changing
+            // not by the initial render, or the visibilty toggle re-render
+            const display = document.getElementById("sus-display");
+            display.classList.add("flash");
+            setTimeout(() => display.classList.remove("flash"), 50);
         }
     }
 }

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -1,0 +1,88 @@
+function createSuspense() {
+    game.settings.register("grimwild", "suspense", {
+        name: "Suspense",
+        scope: "world",
+        config: false,
+        type: Number,
+        default: 0,
+        range: {
+            min: 0
+        }
+    });
+}
+
+function getSuspense() {
+    return game.settings.get("grimwild", "suspense");
+}
+
+function setSuspense(value) {
+    game.settings.set("grimwild", "suspense", value);
+}
+
+class SuspenseTracker {
+    constructor(){}
+
+    suspense = 0;
+    updateCallbacks = new Array();
+
+    addUpdateCallback(fn){
+        this.updateCallbacks.push(fn);
+    }
+
+    #onUpdate() {
+        this.updateCallbacks.forEach(fn =>{
+            try {
+                fn(this.suspense);
+            } catch (exception) {
+                // just log, don't interrupt
+                console.log(exception);
+            }
+        });
+    }
+
+    adjust(amount) {
+        const prev = this.suspense;
+        this.suspense += amount;
+        if (this.suspense < 0) this.suspense = 0;
+        if (this.suspense != prev) {
+            this.#onUpdate();
+        }
+    }
+
+    init() {
+        console.log("Suspense: initialising");
+        createSuspense();
+        this.suspense = getSuspense();
+        this.#onUpdate();
+        this.addUpdateCallback(setSuspense);
+        console.log("Suspense: initialised with value " + this.suspense);
+    }
+
+    render() {
+        const trackerHotBar = document.createElement("div");
+        trackerHotBar.classList.add("suspense-controls");
+        trackerHotBar.innerHTML = `
+        <div id="sus-control-inner">
+            <div id="sus-display">
+                <div id="js-sus-current">${this.suspense}</div>
+                <div id="sus-label">suspense</div>
+            </div>
+            <div id="sus-adjust">
+                <button id="js-sus-up">+</button>
+                <button id="js-sus-dn">-</button>
+            </div>
+        </div>
+        `;
+        document.getElementById("ui-bottom").prepend(trackerHotBar);
+
+        document.getElementById("js-sus-up").onclick = () => this.adjust(1);
+        document.getElementById("js-sus-dn").onclick = () => this.adjust(-1);
+
+        const currentSuspenseDisplay = document.getElementById("js-sus-current");
+        this.addUpdateCallback(suspense => {
+            currentSuspenseDisplay.innerText = suspense;
+        });
+    }
+}
+
+export const SUSPENSE_TRACKER = new SuspenseTracker();

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -1,16 +1,3 @@
-function createSuspense() {
-    game.settings.register("grimwild", "suspense", {
-        name: "Suspense",
-        scope: "world",
-        config: false,
-        type: Number,
-        default: 0,
-        range: {
-            min: 0
-        }
-    });
-}
-
 function getSuspense() {
     return game.settings.get("grimwild", "suspense");
 }
@@ -22,66 +9,66 @@ function setSuspense(value) {
 class SuspenseTracker {
     constructor(){}
 
-    suspense = 0;
-    updateCallbacks = new Array();
-
-    addUpdateCallback(fn){
-        this.updateCallbacks.push(fn);
-    }
-
-    #onUpdate() {
-        this.updateCallbacks.forEach(fn =>{
-            try {
-                fn(this.suspense);
-            } catch (exception) {
-                // just log, don't interrupt
-                console.log(exception);
-            }
-        });
-    }
-
-    adjust(amount) {
-        const prev = this.suspense;
-        this.suspense += amount;
-        if (this.suspense < 0) this.suspense = 0;
-        if (this.suspense != prev) {
-            this.#onUpdate();
-        }
-    }
-
     init() {
         console.log("Suspense: initialising");
-        createSuspense();
-        this.suspense = getSuspense();
-        this.#onUpdate();
-        this.addUpdateCallback(setSuspense);
-        console.log("Suspense: initialised with value " + this.suspense);
+        game.settings.register("grimwild", "suspenseVisible", {
+            name: "Suspense visible to players",
+            hint: "Toggle this on/off to show/hide the suspense tracker for non-GMs",
+            scope: "world",
+            config: true,
+            type: Boolean,
+            default: true,
+            onChange: this.render
+        });
+        game.settings.register("grimwild", "suspense", {
+            name: "Suspense",
+            scope: "world",
+            config: false,
+            type: Number,
+            default: 0,
+            onChange: this.render
+        });
     }
 
     render() {
-        const trackerHotBar = document.createElement("div");
-        trackerHotBar.classList.add("suspense-controls");
-        trackerHotBar.innerHTML = `
+        const isGM = game.user.isGM;
+        const visibleToPlayers = game.settings.get("grimwild", "suspenseVisible");
+
+        let susControl = document.getElementById("sus-control");
+
+        if (!isGM && !visibleToPlayers) {
+            if (susControl) susControl.innerHTML = "";
+            return;
+        }
+
+        const buttonHtml = `
+        <div id="sus-adjust">
+            <button id="js-sus-up">+</button>
+            <button id="js-sus-dn">-</button>
+        </div>`;
+
+        const susControlInnerHTML = `
         <div id="sus-control-inner">
             <div id="sus-display">
-                <div id="js-sus-current">${this.suspense}</div>
+                <div id="sus-current">${getSuspense()}</div>
                 <div id="sus-label">SUSPENSE</div>
             </div>
-            <div id="sus-adjust">
-                <button id="js-sus-up">+</button>
-                <button id="js-sus-dn">-</button>
-            </div>
-        </div>
-        `;
-        document.getElementById("ui-bottom").prepend(trackerHotBar);
+            ${isGM ? buttonHtml : ""}
+        </div>`;
 
-        document.getElementById("js-sus-up").onclick = () => this.adjust(1);
-        document.getElementById("js-sus-dn").onclick = () => this.adjust(-1);
+        if (!susControl) {
+            susControl = document.createElement("div");
+            susControl.setAttribute("id", "sus-control");
+            document.getElementById("ui-bottom").prepend(susControl);
+        }
+        susControl.innerHTML = susControlInnerHTML;
 
-        const currentSuspenseDisplay = document.getElementById("js-sus-current");
-        this.addUpdateCallback(suspense => {
-            currentSuspenseDisplay.innerText = suspense;
-        });
+        if (isGM) {
+            document.getElementById("js-sus-up").onclick = () => setSuspense(getSuspense() + 1);
+            document.getElementById("js-sus-dn").onclick = () => {
+                setSuspense(Math.max(getSuspense() - 1, 0));
+            };
+        }
     }
 }
 

--- a/src/module/grimwild.mjs
+++ b/src/module/grimwild.mjs
@@ -13,6 +13,8 @@ import * as utils from "./helpers/utils.js";
 // Import DataModel classes
 import * as models from "./data/_module.mjs";
 
+import { SUSPENSE_TRACKER } from "./controls/suspense.mjs";
+
 /* -------------------------------------------- */
 /*  Init Hook                                   */
 /* -------------------------------------------- */
@@ -148,6 +150,8 @@ Hooks.once("init", function () {
 		// Call the original Roll.create for other cases
 		return originalCreate.call(this, formula);
 	};
+
+	SUSPENSE_TRACKER.init();
 });
 
 /* -------------------------------------------- */
@@ -166,6 +170,10 @@ Handlebars.registerHelper("toLowerCase", function (str) {
 Hooks.once("ready", function () {
 	// Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
 	Hooks.on("hotbarDrop", (bar, data, slot) => createDocMacro(data, slot));
+});
+
+Hooks.once("renderHotbar", function() {
+	SUSPENSE_TRACKER.render();
 });
 
 /* -------------------------------------------- */

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -44,7 +44,7 @@ button {
     }
 }
 
-#js-sus-current {
+#sus-current {
     padding: 2px;
     font-size: xx-large;
 }

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -1,0 +1,28 @@
+* {
+    color: $c-white;
+    background: $c-black;
+    text-align: center;
+}
+
+#sus-adjust {
+    display: flex;
+    flex-direction: column;
+    min-width: fit-content;
+}
+button {
+    pointer-events: all;
+}
+
+#sus-control-inner {
+    justify-content: left;
+    display: flex;
+}
+
+#sus-display {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+}
+#js-sus-current {
+    height: 50%;
+}

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -1,7 +1,13 @@
 * {
     color: $c-white;
-    background: $c-black;
     text-align: center;
+    font-family: $font-display;
+}
+
+#sus-control-inner {
+    display: flex;
+    justify-content: left;
+    margin: 1px;
 }
 
 #sus-adjust {
@@ -9,20 +15,32 @@
     flex-direction: column;
     min-width: fit-content;
 }
-button {
-    pointer-events: all;
-}
 
-#sus-control-inner {
-    justify-content: left;
-    display: flex;
+button {
+    background: $c-black;
+    pointer-events: all;
+    border-color: $c-dark;
+    margin: 1px;
 }
 
 #sus-display {
+    background: $c-black;
     display: flex;
     flex-direction: column;
     justify-content: end;
+    padding: 2px;
+    border: 1px solid;
+    border-radius: 4px;
+    border-color: $c-dark;
+    margin: 1px;
 }
+
 #js-sus-current {
-    height: 50%;
+    padding: 2px;
+    font-size: xx-large;
+}
+
+#sus-label {
+    padding: 2px;
+    max-height: fit-content;
 }

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -1,7 +1,8 @@
 * {
-    color: $c-white;
+    color: $c-groove;
     text-align: center;
     font-family: $font-display;
+    transition: all 100ms ease-in-out;
 }
 
 #sus-control-inner {
@@ -17,22 +18,30 @@
 }
 
 button {
-    background: $c-black;
+    background-color: color-mix(in srgb, $c-black 70%, transparent 0%);
     pointer-events: all;
     border-color: $c-dark;
     margin: 1px;
+    &:hover {
+        background-color: $c-black;
+        box-shadow: 0 0 10px var(--color-warm-2) inset;
+    }
 }
 
 #sus-display {
-    background: $c-black;
+    background: color-mix(in srgb, $c-black 80%, transparent 0%);
     display: flex;
     flex-direction: column;
     justify-content: end;
     padding: 2px;
-    border: 1px solid;
+    border: 2px solid;
     border-radius: 4px;
     border-color: $c-dark;
     margin: 1px;
+    pointer-events: all;
+    &:hover {
+        background-color: $c-black;
+    }
 }
 
 #js-sus-current {

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -42,6 +42,9 @@ button {
     &:hover {
         background-color: $c-black;
     }
+    &.flash {
+        box-shadow: 0 0 40px var(--color-warm-2) inset;
+    }
 }
 
 #sus-current {

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -55,4 +55,5 @@ button {
 #sus-label {
     padding: 2px;
     max-height: fit-content;
+    text-transform: uppercase;
 }

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -38,6 +38,6 @@
   @import 'components/dialog';
 }
 
-.suspense-controls {
+#sus-control {
   @import 'components/suspense';
 }

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -37,3 +37,7 @@
 .dialog {
   @import 'components/dialog';
 }
+
+.suspense-controls {
+  @import 'components/suspense';
+}


### PR DESCRIPTION
Adds a suspense tracker to the bottom UI, just above the macro hotbar.

The suspense value is stored as a system setting, letting it sync and trigger re-renders for all users.
An additional system setting lets the GM hide the tracker for players.

Short demo, showing GM (left) and player (right) views side by side.
![suspense tracker demo](https://github.com/user-attachments/assets/659bacce-3e7a-40ec-b099-497dd5d68b2e)
