### PR TITLE
Bail out when roll dialog closed

### DIFF
--- a/src/module/data/actor-character.mjs
+++ b/src/module/data/actor-character.mjs
@@ -244,7 +244,10 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 					isMarked: rollData?.stats?.[options.stat].marked
 				}
 			});
-
+			// bail out if they closed the dialog
+			if (rollDialog === null) {
+				return;
+			}
 			rollData.thorns = rollDialog.thorns;
 			rollData.statDice = rollDialog.dice;
 			options.assists = rollDialog.assisters;


### PR DESCRIPTION
This fixes a console error when closing the roll dialog box. This was occuring because the roll function assumed values were being returned from the dialog, but when it is closed, the return value is `null`.