### PR TITLE
Make quick pools only editable for GMs

### DIFF
--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -43,9 +43,10 @@ function getScenePools() {
 				</div>
 			`).join('')}
 		</div>
-		<div class="quick-pool-adjust">
+		${game.user.isGM ?
+			`<div class="quick-pool-adjust">
 			<button class="hover-highlight js-quick-pool-add">+ Pool</button>
-		</div>
+		</div>` : ''}
 	</div>
 	`;
 	return poolHtml;

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -20,6 +20,7 @@ function getScenePools() {
 	if (!scene) return '';
 
 	const pools = scene.getFlag('grimwild', 'quickPools') ?? [];
+	const editable = game.user.isGM ? `contentEditable="plaintext-only"` : '';
 	const poolHtml = `
 	<div class="quick-pool-inner">
 		<div class="quick-pool-list">
@@ -27,12 +28,12 @@ function getScenePools() {
 				<div class="quick-pool">
 					<div class="quick-pool-content">
 						<div class="quick-pool-current">
-							<span class="js-quick-pool-text" contentEditable="plaintext-only" data-pool="${index}" data-field="diceNum">${pool.diceNum}</span>d
+							<span class="js-quick-pool-text" ${editable} data-pool="${index}" data-field="diceNum">${pool.diceNum}</span>d
 						</div>
 						${game.user.isGM ? `<button class="js-quick-pool-roll" type="button" data-roll-data="${pool.diceNum}" data-pool="${index}"><i class="fas fa-dice-d6"></i></button>` : ''}
 					</div>
 					<div class="quick-pool-label">
-						<span class="js-quick-pool-text" contentEditable="plaintext-only" data-pool="${index}" data-field="label">${pool.label}</span>
+						<span class="js-quick-pool-text" ${editable} data-pool="${index}" data-field="label">${pool.label}</span>
 						${game.user.isGM ? `<button class="js-quick-pool-delete" data-pool="${index}" type="button"><i class="fas fa-trash"></i></button>` : ''}
 					</div>
 				</div>

--- a/src/module/controls/suspense.mjs
+++ b/src/module/controls/suspense.mjs
@@ -25,22 +25,26 @@ function getScenePools() {
 	<div class="quick-pool-inner">
 		<div class="quick-pool-list">
 			${pools.map((pool, index) => `
-				<div class="quick-pool">
-					<div class="quick-pool-content">
+				<div class="quick-pool flex-row">
+					<div class="flex-col">
 						<div class="quick-pool-current">
 							<span class="js-quick-pool-text" ${editable} data-pool="${index}" data-field="diceNum">${pool.diceNum}</span>d
 						</div>
-						${game.user.isGM ? `<button class="js-quick-pool-roll" type="button" data-roll-data="${pool.diceNum}" data-pool="${index}"><i class="fas fa-dice-d6"></i></button>` : ''}
+						<div class="quick-pool-label">
+							<span class="js-quick-pool-text" ${editable} data-pool="${index}" data-field="label">${pool.label}</span>
+						</div>
 					</div>
-					<div class="quick-pool-label">
-						<span class="js-quick-pool-text" ${editable} data-pool="${index}" data-field="label">${pool.label}</span>
-						${game.user.isGM ? `<button class="js-quick-pool-delete" data-pool="${index}" type="button"><i class="fas fa-trash"></i></button>` : ''}
-					</div>
+					${game.user.isGM ? 
+					`<div class="flex-col">
+						<button class="inner hover-highlight-icon js-quick-pool-roll" type="button" data-roll-data="${pool.diceNum}" data-pool="${index}"><i class="fas fa-dice-d6"></i></button>
+						<button class="inner hover-highlight-icon js-quick-pool-delete" data-pool="${index}" type="button"><i class="fas fa-trash"></i></button>
+					</div>` : ''
+					}
 				</div>
 			`).join('')}
 		</div>
 		<div class="quick-pool-adjust">
-			<button class="js-quick-pool-add">+ Pool</button>
+			<button class="hover-highlight js-quick-pool-add">+ Pool</button>
 		</div>
 	</div>
 	`;
@@ -98,14 +102,14 @@ class SuspenseTracker {
 
 		const buttonHtml = `
 		<div id="sus-adjust">
-			<button id="js-sus-up">+</button>
-			<button id="js-sus-dn">-</button>
+			<button class="hover-highlight" id="js-sus-up">+</button>
+			<button class="hover-highlight" id="js-sus-dn">-</button>
 		</div>`;
 
 		const label = game.i18n.localize("GRIMWILD.Resources.suspense");
 		const susControlInnerHTML = `
 		<div id="sus-control-inner">
-			<div id="sus-display">
+			<div id="sus-display" class="flex-col">
 				<div id="sus-current">${getSuspense()}</div>
 				<div id="sus-label">${label}</div>
 			</div>
@@ -154,6 +158,7 @@ class SuspenseTracker {
 			}));
 
 			document.querySelectorAll('.js-quick-pool-roll').forEach(element => element.addEventListener('click', async (event) => {
+				console.log(event);
 				let { rollData, pool } = event.currentTarget.dataset;
 				rollData = Number.isNumeric(rollData) ? Number(rollData) : 0;
 				const scene = getScene();

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -22,18 +22,21 @@ button {
 	flex: 1;
 	color: var(--color-text-light-highlight);
 
-	&:hover {
-		background-color: var(--sus-bg-highlight);
-		box-shadow: 0 0 10px var(--color-warm-2) inset;
+	&.inner {
+		background: none;
+		border-style: none;
 	}
 }
 
-.quick-pool-content {
-	display: flex;
+button.hover-highlight:hover {
+	background-color: var(--sus-bg-highlight);
+	box-shadow: 0 0 10px var(--color-warm-2) inset;
+}
 
-	button {
-		flex: 0;
-		line-height: 1;
+button.hover-highlight-icon:hover {
+	box-shadow: none;
+	i {
+		text-shadow: 0 0 10px var(--color-warm-2);
 	}
 }
 
@@ -53,12 +56,22 @@ button {
 	overflow-x: auto;
 }
 
+.flex-col {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+}
+
+.flex-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
 #sus-display,
 .quick-pool {
 	background: var(--sus-bg);
-	display: flex;
-	flex-direction: column;
-	justify-content: end;
+	
 	padding: 2px;
 	border: 2px solid;
 	border-radius: 4px;

--- a/src/styles/components/_suspense.scss
+++ b/src/styles/components/_suspense.scss
@@ -13,6 +13,11 @@
 	gap: 2px;
 }
 
+.quick-pool-adjust {
+	writing-mode: vertical-rl;
+	text-orientation: mixed;
+}
+
 button {
 	background-color: var(--sus-bg);
 	pointer-events: all;


### PR DESCRIPTION
Noticed players were able to edit pools, but their edits don't actually carry over. I think we should just disable this and have the GM manage quick pools.

Also includes other minor adjustments, mostly visual:
- sus control bar no longer needs to grow in size to accommodate quick pools
- quick pool buttons highlight on hover, instead of being inside a button
- removes `+ Pool` button for players
- changes orientation of `+ Pool` text so that the button is more compact

![Quick Pool visual adjustments demo](https://github.com/user-attachments/assets/fff348cc-bac8-4744-8303-0c2728041524)
