### PR TITLE
Respect roll privacy

### DIFF
--- a/src/module/dice/die-pools.mjs
+++ b/src/module/dice/die-pools.mjs
@@ -13,7 +13,7 @@ export default class GrimwildDiePoolRoll extends Roll {
 			dice: this.dice[0].results,
 			startPool: isPrivate ? "???" : "",
 			endPool: isPrivate ? "???" : "",
-			isPrivate: isPrivate,
+			isPrivate: isPrivate
 		};
 
 		const dropped = chatData.dice.filter((die) => die.result < 4);

--- a/src/module/dice/die-pools.mjs
+++ b/src/module/dice/die-pools.mjs
@@ -12,7 +12,8 @@ export default class GrimwildDiePoolRoll extends Roll {
 			stat: this.options.stat,
 			dice: this.dice[0].results,
 			startPool: isPrivate ? "???" : "",
-			endPool: isPrivate ? "???" : ""
+			endPool: isPrivate ? "???" : "",
+			isPrivate: isPrivate,
 		};
 
 		const dropped = chatData.dice.filter((die) => die.result < 4);

--- a/src/module/dice/rolls.mjs
+++ b/src/module/dice/rolls.mjs
@@ -18,7 +18,7 @@ export default class GrimwildRoll extends Roll {
 			rawSuccess: 0,
 			rawResult: "",
 			isCut: false,
-			isPrivate: isPrivate,
+			isPrivate: isPrivate
 		};
 
 		const sixes = chatData.dice.filter((die) => die.result === 6);

--- a/src/module/dice/rolls.mjs
+++ b/src/module/dice/rolls.mjs
@@ -17,7 +17,8 @@ export default class GrimwildRoll extends Roll {
 			success: 0,
 			rawSuccess: 0,
 			rawResult: "",
-			isCut: false
+			isCut: false,
+			isPrivate: isPrivate,
 		};
 
 		const sixes = chatData.dice.filter((die) => die.result === 6);

--- a/src/templates/chat/die-pool-action.hbs
+++ b/src/templates/chat/die-pool-action.hbs
@@ -1,3 +1,4 @@
+{{#unless isPrivate}}
 <section class="grimwild-chat grimwild-roll {{result}}">
   <h2>{{ startPool }} &#8594; {{ endPool }}</h2>
   <em>{{stat}}</em>
@@ -13,3 +14,4 @@
     </section>
   </div>
 </section>
+{{/unless}}

--- a/src/templates/chat/roll-action.hbs
+++ b/src/templates/chat/roll-action.hbs
@@ -1,3 +1,4 @@
+{{#unless isPrivate}}
 <section class="grimwild-chat grimwild-roll {{result}}">
   <h2>{{#if isCut }}
     {{localize (concat "GRIMWILD.Dice.results." rawResult)}} &#8594; 
@@ -29,3 +30,4 @@
     </section>
   </div>
 </section>
+{{/unless}}


### PR DESCRIPTION
Confirmed that this still shows all rolls to the GM, but private rolls are otherwise only shown in chat to the player that rolled them