### PR TITLE
Sanity check and synchronize related character fields

### DIFF
--- a/src/module/data/actor-character.mjs
+++ b/src/module/data/actor-character.mjs
@@ -173,6 +173,42 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 		return orderedStats;
 	}
 
+	async _preUpdate(changes, options, user) {
+		const checkPool = (change, source) => {
+			if (change) {
+				// Start the healing pool
+				if (change.marked && !source.marked && !change.pool.diceNum && !source.pool.diceNum) {
+					change.pool.diceNum = 3;
+				}
+				// Cancel the healing pool
+				if (!change.marked && source.marked && change.pool.diceNum == source.pool.diceNum) {
+					change.pool.diceNum = 0;
+				}
+				// Pool expired
+				if (source.marked && !change.pool.diceNum && source.pool.diceNum) {
+					change.marked = false;
+				}
+			}
+		}
+		checkPool(changes.system.bloodied, this._source.bloodied);
+		checkPool(changes.system.rattled, this._source.rattled);
+
+		const checkSteps = (change, source) => {
+			if (change) {
+				// Mark both
+				if (!source.steps[1] && change.steps[1] && !change.steps[0]) {
+					change.steps[0] = true;
+				}
+				// Clear both
+				if (source.steps[0] && change.steps[1] && !change.steps[0]) {
+					change.steps[1] = false;
+				}
+			}
+		}
+		checkSteps(changes.system.spark, this._source.spark);
+		checkSteps(changes.system.story, this._source.story);
+	}
+
 	prepareDerivedData() {
 		// Loop through stat scores, and add their modifiers to our sheet output.
 		for (const key in this.stats) {


### PR DESCRIPTION
- When marking bloodied or rattled, set the relevant 3d healing pool
- When clearing bloodied or rattled, clear the healing pool
- When clearing the healing pool, also clear the harm mark
- Make sure step 0 of spark or story is not cleared when step 1 is set, try to make useful assumptions when toggling steps