### PR TITLE
Fix an issue with character preupdate events when they contain no system data (e.g. permission change)

### DIFF
--- a/src/module/data/actor-character.mjs
+++ b/src/module/data/actor-character.mjs
@@ -192,8 +192,8 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 				}
 			}
 		}
-		checkPool(changes.system.bloodied, this._source.bloodied);
-		checkPool(changes.system.rattled, this._source.rattled);
+		checkPool(changes.system?.bloodied, this._source.bloodied);
+		checkPool(changes.system?.rattled, this._source.rattled);
 
 		const checkSteps = (change, source) => {
 			if (change) {
@@ -207,8 +207,8 @@ export default class GrimwildCharacter extends GrimwildActorBase {
 				}
 			}
 		}
-		checkSteps(changes.system.spark, this._source.spark);
-		checkSteps(changes.system.story, this._source.story);
+		checkSteps(changes.system?.spark, this._source.spark);
+		checkSteps(changes.system?.story, this._source.story);
 	}
 
 	prepareDerivedData() {


### PR DESCRIPTION
This addresses an issue in my last PR that would cause actor permission changes to fail