### PR TITLE
Add Monsters compendium

### DIFF
--- a/src/packs/monsters/Basilisk_r5qBaLthS6ISJLRs.yml
+++ b/src/packs/monsters/Basilisk_r5qBaLthS6ISJLRs.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Basilisk
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Spiny, eight-legged reptiles that lurk in forgotten, shadowy places. They
+    patiently lay in wait to ambush prey, then feast on the petrified
+    remains.</p>
+  notes: ''
+  role: lurker
+  tier: tough
+  traits:
+    - Sluggish Stealth
+    - Spiny Hide
+    - Keen Sense of Smell
+  moves:
+    - Petrifying Gaze
+    - Bite & Thrash
+    - Slink Away
+  desires:
+    - value: to munch on a delicious statue, later.
+      are: false
+    - value: light revealing its hiding places.
+      are: false
+  sensories:
+    colors:
+      - name: scaly green
+        color: '#566b30'
+      - name: mossy brown
+        color: '#8b4512'
+      - name: rocky gray
+        color: '#708090'
+    sights: gleam of scales, slithering trails through dust
+    sounds: silence, rasping hiss, crunching of chewed stone
+    smells: chalky scent of ground stone, desiccated air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hiding Spots
+      instructions: ''
+      table:
+        - - Beneath a crumbling, but still-used bridge.
+          - Within the rotting carcass of a fallen dragon.
+          - On the fifth floor of a derelict watchtower.
+          - In a field full of half-eaten bear statues.
+          - Within a maze of rusted, echoing pipes.
+          - Among the twisted roots of a giant tree.
+prototypeToken:
+  name: Basilisk
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368340356
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: r5qBaLthS6ISJLRs
+sort: 100000
+_key: '!actors!r5qBaLthS6ISJLRs'
+

--- a/src/packs/monsters/Behir_H2ERCtGIG1rUUjzc.yml
+++ b/src/packs/monsters/Behir_H2ERCtGIG1rUUjzc.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Behir
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, solitary serpentine creatures with a dozen legs and brilliant
+    azure scales. They live in dark, decaying places and rarely tolerate
+    intruders.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Cling to Walls
+    - Serpentine Flexibility
+    - Speech
+  moves:
+    - Electric Breath
+    - Bite & Constrict
+    - Swallow Whole
+  desires:
+    - value: to find a new safe hunting territory.
+      are: false
+    - value: rival predators challenging its territory.
+      are: false
+  sensories:
+    colors:
+      - name: Scaly Gray
+        color: '#2f4f4e'
+      - name: Stormy Gray
+        color: '#696969'
+      - name: Azure Blue
+        color: '#4682b4'
+    sights: deep claw marks, static sparks, lightning strike marks
+    sounds: sizzling electric snaps, sudden boom, shuffling legs
+    smells: metallic tang, faint acrid smell, scorched hide
+  pool:
+    diceNum: 6
+    max: null
+  tables:
+    - name: Unearthed by ...
+      instructions: ''
+      table:
+        - - Landslide during a massive thunderstorm.
+          - Generational flood wiping out whole villages.
+          - Earthquake toppling castle walls.
+          - Collapse of a silver mine, forcing it to flee.
+          - Lich's minions dug too deep.
+          - Adventurers left an almost empty dungeon.
+prototypeToken:
+  name: Behir
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: null
+  bar2:
+    attribute: null
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 0
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368347484
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: H2ERCtGIG1rUUjzc
+sort: 200000
+_key: '!actors!H2ERCtGIG1rUUjzc'
+

--- a/src/packs/monsters/Carcass_Crawler_cReBxMdewr95WX6h.yml
+++ b/src/packs/monsters/Carcass_Crawler_cReBxMdewr95WX6h.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Carcass Crawler
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, slimy worms with dozens of grasping tentacles, lurking
+    underground to feast on dead or paralyzed prey. They're drawn to the scent
+    of death.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Paralytic Touch
+    - Cling to Walls
+  moves:
+    - Tentacle Slaps
+    - Spew Bile
+    - Brief Scuttle
+  desires:
+    - value: more flesh, always more flesh.
+      are: false
+    - value: to suffer the sheer panic of hunger.
+      are: false
+  sensories:
+    colors:
+      - name: Rotten Brown
+        color: '#8b4512'
+      - name: Dull Olive
+        color: '#6a8e22'
+      - name: Vile Green
+        color: '#566b30'
+    sights: pristine bones, writhing tentacles, clouds of flies
+    sounds: wet slithering, grotesque squelching, bone snaps
+    smells: rancid stench, sickly-sweet venom, mold and rot
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Feeding Grounds
+      instructions: ''
+      table:
+        - - The remnants of a horrific battle.
+          - The result of a successful deateh cult.
+          - A recently thawed graveyard.
+          - A plague that killed herds of farm animals.
+          - A fleet of invasion ships dashed against rocks.
+          - Mass sacrifices to it, worshipped as a god.
+prototypeToken:
+  name: Carcass Crawler
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368348365
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: cReBxMdewr95WX6h
+sort: 300000
+_key: '!actors!cReBxMdewr95WX6h'
+

--- a/src/packs/monsters/Chimera_wZG3CtLI7QoykRaY.yml
+++ b/src/packs/monsters/Chimera_wZG3CtLI7QoykRaY.yml
@@ -1,0 +1,161 @@
+folder: null
+name: Chimera
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Violent, chaotic monstrous hybrids of a lion, goat, and dragon. They
+    rarely stay in one place long, suffering relentless wanderlust.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Multi-headed
+    - Unpredictable
+    - Understands Language
+  moves:
+    - Fire Breath
+    - Flying Pounce
+    - Claw, Bite, Horns
+  desires:
+    - value: to keep wandering.
+      are: false
+    - value: to face choices that its heads disagree on.
+      are: false
+  sensories:
+    colors:
+      - name: Dark Brown
+        color: '#654320'
+      - name: Burnt Umber
+        color: '#8a3224'
+      - name: Fiery Red
+        color: '#b22222'
+    sights: streaks of scorched earth, smoke from its nostrils
+    sounds: growls, roars, and hisses, sudden woosh and crackle
+    smells: acrid scent of sulfur and ash, musky wet fur
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hybrid Heads
+      instructions: Roll 3 times
+      table:
+        - - wolverine
+          - dingo
+          - anteater
+          - condor
+          - rattlesnake
+          - platypus
+        - - rhino
+          - baboon
+          - mantis
+          - alligator
+          - ostrich
+          - mongoose
+        - - vampire bat
+          - sloth
+          - jackal
+          - gila monster
+          - pangolin
+          - cobra
+prototypeToken:
+  name: Chimera
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368349482
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: wZG3CtLI7QoykRaY
+sort: 400000
+_key: '!actors!wZG3CtLI7QoykRaY'
+

--- a/src/packs/monsters/Chuul_7CZfQgXnf2GH5GcC.yml
+++ b/src/packs/monsters/Chuul_7CZfQgXnf2GH5GcC.yml
@@ -1,0 +1,155 @@
+folder: null
+name: Chuul
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Enormous, lobster-like aberrations with a mouthful of tentacles. They are
+    drawn to magic and hoard the relics they find in their cluttered lairs.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Hardened Shell
+    - Sense Nearby Magic
+    - Speech
+  moves:
+    - Stunning Tentacle
+    - Claw Lock
+    - Drag Under
+  desires:
+    - value: to hoard sources of magic, instinctually.
+      are: false
+    - value: to venture far from the moistness of the swamp.
+      are: false
+  sensories:
+    colors:
+      - name: Crustacean Brown
+        color: '#8b4512'
+      - name: Deep Yellow
+        color: '#d3af37'
+      - name: Swamp Green
+        color: '#566b30'
+    sights: roiling water, slick tendrils
+    sounds: bubbling groan of water, wet slap of tentacles
+    smells: cloying tang of magic, pungent crustacean odor
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Eldritch Mutations Crucible
+      instructions: Roll 2d6.
+      table:
+        - - acidic
+          - spiked
+          - reflective
+          - extendable
+          - glowing
+          - magic-sensing
+        - - shell
+          - eyestalks
+          - wings
+          - antennae
+          - tail
+          - claws
+prototypeToken:
+  name: Chuul
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368361757
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 7CZfQgXnf2GH5GcC
+sort: 500000
+_key: '!actors!7CZfQgXnf2GH5GcC'
+

--- a/src/packs/monsters/Cockatrice_OCHBnFmRajnUX0Ay.yml
+++ b/src/packs/monsters/Cockatrice_OCHBnFmRajnUX0Ay.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Cockatrice
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Small, chicken-like creatures with reptilian features. They roam in
+    flocks and their peck turns flesh to stone, which they use to mark their
+    territory.</p>
+  notes: ''
+  role: swarmer
+  tier: tough
+  traits:
+    - Flocking Instinct
+    - Ferocious Swarming
+  moves:
+    - Petrifying Pecks
+    - Winged Retreat
+    - Flappy Distraction
+  desires:
+    - value: to mark its territory with petrified victims.
+      are: false
+    - value: to have its flock's authority challenged.
+      are: false
+  sensories:
+    colors:
+      - name: Rust Orange
+        color: '#cd5d5c'
+      - name: Feathered Brown
+        color: '#a0522c'
+      - name: Dusky Gold
+        color: '#daa521'
+    sights: small petrified animals, mass of scattered feathers
+    sounds: flurry of wings, chorus of shrill squawks, beak snaps
+    smells: mismatched smell of feathers and scales
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Migrations
+      instructions: ''
+      table:
+        - - Onto an island, home to a monastery.
+          - Into a small hamlet, everyone stuck indoors.
+          - Into a valley, an important trade crossroad.
+          - Throughout a city, absolute chaos ensuing.
+          - Down into mines, trapping miners inside.
+          - Aboard a large ship anchored in the bay.
+prototypeToken:
+  name: Cockatrice
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368362688
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: OCHBnFmRajnUX0Ay
+sort: 600000
+_key: '!actors!OCHBnFmRajnUX0Ay'
+

--- a/src/packs/monsters/Couatl_tSmFJAIUbuI5gjOB.yml
+++ b/src/packs/monsters/Couatl_tSmFJAIUbuI5gjOB.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Couatl
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Celestial serpents with rainbow feathers that act as wise protectors and
+    guardians of sacred places. They seek to preserve balance and impart
+    wisdom.</p>
+  notes: ''
+  role: protector
+  tier: tough
+  traits:
+    - Truthbound
+    - Shapechanger
+    - Telepathy
+  moves:
+    - Read Minds
+    - Constrict
+    - Radiant Magic
+  desires:
+    - value: to ensure sacred sites stay hidden.
+      are: false
+    - value: its wisdom being ignored.
+      are: false
+  sensories:
+    colors:
+      - name: Bronze Gold
+        color: '#b8860b'
+      - name: Iridescent Blue
+        color: '#4682b4'
+      - name: Emerald Green
+        color: '#51c878'
+    sights: iridescent scales, vivid feathers, trail of light
+    sounds: otherwordly hum, gentle rustling, whispering winds
+    smells: clean fresh breeze, soothing incense, hopeful magic
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Sacred Task
+      instructions: ''
+      table:
+        - - Retrieve a sacred artifact, your sword.
+          - Protect a chosen one, your enemy.
+          - Find ancient knowledge, your secret.
+          - Teach you a forgotten language.
+          - Stop you from destroying the world.
+          - Tricked by a devil into destroying you.
+prototypeToken:
+  name: Couatl
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368363454
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: tSmFJAIUbuI5gjOB
+sort: 700000
+_key: '!actors!tSmFJAIUbuI5gjOB'
+

--- a/src/packs/monsters/Cyclops_bnAWVuU4FJnP5xbx.yml
+++ b/src/packs/monsters/Cyclops_bnAWVuU4FJnP5xbx.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Cyclops
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Solitary, towering figures that value their personal territory above all
+    else. They gather boulders and stones, treating them as symbols of
+    power.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Singular, Intense Focus
+    - Immensely Strong
+    - Understands L6anguage
+  moves:
+    - Boulder Toss
+    - Ground Slam
+    - Fearsome Bellow
+  desires:
+    - value: boulder caches, a symbol of territory and power.
+      are: false
+    - value: to get distracted or feel like it's being tricked.
+      are: false
+  sensories:
+    colors:
+      - name: Weathered Beige
+        color: '#d1b48c'
+      - name: Eyeball White
+        color: '#e8e8e6'
+      - name: Stone Brown
+        color: '#8b4512'
+    sights: piles of boulders, massive cave entrance
+    sounds: guttural rumbling, whoosh of a boulder flying
+    smells: unwashed skin, earthy cave, sharp stone dust
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Cyclopean Curses
+      instructions: ''
+      table:
+        - - It can only see at night.
+          - It can only venture outside in the rain.
+          - Its every footstep causes a tremour.
+          - It's terrified of small mammals.
+          - It can never stop walking.
+          - It's lonely, the last of its kind.
+prototypeToken:
+  name: Cyclops
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368364130
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: bnAWVuU4FJnP5xbx
+sort: 800000
+_key: '!actors!bnAWVuU4FJnP5xbx'
+

--- a/src/packs/monsters/Demon__Balor_4K0jDJ6DG6aSnqpI.yml
+++ b/src/packs/monsters/Demon__Balor_4K0jDJ6DG6aSnqpI.yml
@@ -1,0 +1,342 @@
+folder: null
+name: Demon, Balor
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering embodiments of pure evil, with massive bat-like wings. They rule
+    with chaos and destruction, and have an insatiable hunger for more
+    power.</p>
+  notes: >-
+    <p>Story pitch: HELL TO PAY.</p><p>"The balor emerges from the shattered
+    summoning circle as the cathedral erupts in flames around it. Those who
+    disturbed it lie dead and now the capital will feel its fury."</p>
+  role: overseer
+  tier: tough
+  traits:
+    - Pierces Deceptions
+    - Fiery Aura
+    - Speech, Telepathy
+  moves:
+    - Burning Whip
+    - Crackling Sword
+    - Booming Teleport
+  desires:
+    - value: to bask in its own greatness.
+      are: false
+    - value: its absolute control to waver, even for a second.
+      are: false
+  sensories:
+    colors:
+      - name: Inferno Red
+        color: '#b22222'
+      - name: Smoky Black
+        color: '#2f2f2f'
+      - name: Ember Orange
+        color: '#ff4500'
+    sights: chaotic dancing flames, large smoking footprints
+    sounds: whip cracks, crackling lightning, guttural chanting
+    smells: overwhelming brimstone, smothering ash
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Death Throes
+      instructions: Roll 2
+      table:
+        - - Devastating explosion, reducing all to ash.
+          - Brilliant flash, blinding all that witness it.
+          - Lava geysers erupt from the ground.
+          - Hellfire meteors bombard the area.
+          - Blazing cyclone and molten rain wreak havoc.
+          - A portal to the abyss opens, compelling entrance.
+prototypeToken:
+  name: Demon, Balor
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Head
+    type: challenge
+    _id: pDGl6EoysNRgf25k
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Well-defended
+      moves:
+        - Horrific Taunts
+        - Cruel
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!4K0jDJ6DG6aSnqpI.pDGl6EoysNRgf25k'
+  - name: Burning Whip
+    type: challenge
+    _id: rm165nOj5917NVJJ
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Protects the Head
+      moves:
+        - Whipcrack
+        - Drag in close
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!4K0jDJ6DG6aSnqpI.rm165nOj5917NVJJ'
+  - name: Demonic Magic
+    type: challenge
+    _id: Fy9mzsxl1NjlYTGj
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Ward the balor
+      moves:
+        - Summon Demons
+        - Create Firestorm
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!4K0jDJ6DG6aSnqpI.Fy9mzsxl1NjlYTGj'
+  - name: Crackling Sword
+    type: challenge
+    _id: IQIwLgygxAPNaiPM
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Protects the head
+      moves:
+        - Behead
+        - Arcing Strike
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!4K0jDJ6DG6aSnqpI.IQIwLgygxAPNaiPM'
+  - name: Body
+    type: challenge
+    _id: 37wVsrVhRvbo5fyX
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Impenetrable Hide
+        - Immensely strong
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!4K0jDJ6DG6aSnqpI.37wVsrVhRvbo5fyX'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368365475
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 4K0jDJ6DG6aSnqpI
+sort: 900000
+_key: '!actors!4K0jDJ6DG6aSnqpI'
+

--- a/src/packs/monsters/Demon__Glabrezu_pxcakZvABap6b3DM.yml
+++ b/src/packs/monsters/Demon__Glabrezu_pxcakZvABap6b3DM.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Demon, Glabrezu
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Hulking fiends with four arms, two of which are claws. They tempt
+    ambitious mortals, granting wishes and delighting as it all backfires.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Devious Schemer
+    - Magic Resistance
+    - Speech, Telepathy
+  moves:
+    - Create Darkness
+    - Know Desires
+    - Grant Wish
+  desires:
+    - value: to know what would make you happy.
+      are: false
+    - value: for its offers to be turned down.
+      are: false
+  sensories:
+    colors:
+      - name: Blood Red
+        color: '#8b0101'
+      - name: Demonic Purple
+        color: '#690dac'
+      - name: Deep Gray
+        color: '#696969'
+    sights: stone gouged away, hulking silhouette, eerie glow
+    sounds: faint whispers of magic, clicking claws, alluring voice
+    smells: bitter burnt incense, unknown sickly-sweet aromas
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Wishes Granted (with ruin soon to follow)
+      instructions: ''
+      table:
+        - - Love, leading to the death of their beloved.
+          - Wealth, leading to never-satiated greed.
+          - Wisdom, leading to a descent into madness.
+          - Victory, leading to guilt on how it was won.
+          - Beauty, leading to horror as it fades even a little.
+          - Fame, leading to jealousy from those close.
+prototypeToken:
+  name: Demon, Glabrezu
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368366105
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: pxcakZvABap6b3DM
+sort: 1000000
+_key: '!actors!pxcakZvABap6b3DM'
+

--- a/src/packs/monsters/Demon__Vrock_588OtbbaS3lUhBH3.yml
+++ b/src/packs/monsters/Demon__Vrock_588OtbbaS3lUhBH3.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Demon, Vrock
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>A vulture-like fiend that is drawn to the mayhem of battlefields. They
+    spread poisonous spores with each wingbeat, reveling in the chaos it brings
+    below.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Terrifying Flight
+    - Disgusting Plumage
+    - Understands Language
+  moves:
+    - Deafening Screech
+    - Spore Cloud
+    - Summon Flock
+  desires:
+    - value: to keep the battle going as long as possible.
+      are: false
+    - value: to be drawn directly into the conflict itself.
+      are: false
+  sensories:
+    colors:
+      - name: Feathered Gray
+        color: '#708090'
+      - name: Sickly Green
+        color: '#566b30'
+      - name: Bone White
+        color: '#d7d4c5'
+    sights: cloud of spores, dark shadow, ichor-covered feathers
+    sounds: wet slapping of wings, rustle of diseased feathers
+    smells: rancid decay, spores clogging nostrils
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Spore Effects
+      instructions: ''
+      table:
+        - - Betrayal, poisoning trust between allies.
+          - Terror, causing reckless desperation.
+          - Visions, twisting allies into horrors.
+          - Rage, swelling into extreme bloodlust.
+          - Envy, breeding treacherous ambition.
+          - Heroism, turning into self-sacrificial madness.
+prototypeToken:
+  name: Demon, Vrock
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368366750
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 588OtbbaS3lUhBH3
+sort: 1100000
+_key: '!actors!588OtbbaS3lUhBH3'
+

--- a/src/packs/monsters/Devil__Barbed_iF3Cx4WpibNVplLw.yml
+++ b/src/packs/monsters/Devil__Barbed_iF3Cx4WpibNVplLw.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Devil, Barbed
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Horrific fiends covered in jagged barbs. They savor fear and torment,
+    often stretching out the suffering as long as possible before deliving the
+    final blow.</p>
+  notes: ''
+  role: lurker
+  tier: tough
+  traits:
+    - Hooked Barbs
+    - Horrifying Presence
+    - Speech, Telepathy
+  moves:
+    - Barbed embrace
+    - Throw Hellfire
+    - Slow Taunting
+  desires:
+    - value: to slowly savor the agony and pleas of mercy.
+      are: false
+    - value: for the pain it inflicts to be endured.
+      are: false
+  sensories:
+    colors:
+      - name: Soot Black
+        color: '#2f2f2f'
+      - name: Ember Red
+        color: '#b22222'
+      - name: Dark green
+        color: '#566b30'
+    sights: shadows writhing unnaturally, barbs twitching
+    sounds: scratching of barbs along walls, tearing sound of flesh
+    smells: coppery fresh blood and agony
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Summoned into ...
+      instructions: ''
+      table:
+        - - Royal wedding, meant to seal a fragile peace.
+          - Public execution, meant to crush rebellion.
+          - Temple consecration, meant to ward off evil.
+          - Feast marking the end of a great famine.
+          - Trial of a beloved noble, accused of treason.
+          - Coronation of a hesitant ruler, full of doubt.
+prototypeToken:
+  name: Devil, Barbed
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368367995
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: iF3Cx4WpibNVplLw
+sort: 1200000
+_key: '!actors!iF3Cx4WpibNVplLw'
+

--- a/src/packs/monsters/Devil__Chain_uTgOZVBQhPQRnX4k.yml
+++ b/src/packs/monsters/Devil__Chain_uTgOZVBQhPQRnX4k.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Devil, Chain
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Sadistic fiends that manipulate chains like serpents to ensnare and flay
+    their victims. They relish in the terror and struggle of their confined
+    captives.</p>
+  notes: ''
+  role: tactician
+  tier: tough
+  traits:
+    - Animated Chains Aura
+    - Serrated Links
+    - Speech, Telepathy
+  moves:
+    - Summon Chains
+    - Chain Lash
+    - Reel in
+  desires:
+    - value: its victims to resist before breaking.
+      are: false
+    - value: to find itself confined by others.
+      are: false
+  sensories:
+    colors:
+      - name: Iron Gray
+        color: '#4b4b4b'
+      - name: Steel Blue
+        color: '#3e5c80'
+      - name: Crimson Red
+        color: '#8b0101'
+    sights: glinting metal, slow chain shadows, slow laughter
+    sounds: clinking and rattling, tightening snaps, clangs
+    smells: rusty, reeking metal, pungent sweat and fear
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Imprisoned within ...
+      instructions: ''
+      table:
+        - - Labyrinthine halls of the mad queen.
+          - Cursed portrait in a lavish hall.
+          - Steamy, opulent bathhouse in the capital.
+          - Reliquary of a respected temple.
+          - Trade guild vault, sealed with powerful runes.
+          - Winding forest pathways surrounding town.
+prototypeToken:
+  name: Devil, Chain
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368368896
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: uTgOZVBQhPQRnX4k
+sort: 1300000
+_key: '!actors!uTgOZVBQhPQRnX4k'
+

--- a/src/packs/monsters/Devil__Horned_BEaokrIlmFWOSoVk.yml
+++ b/src/packs/monsters/Devil__Horned_BEaokrIlmFWOSoVk.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Devil, Horned
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fearsome, powerful fiends with towering horns, a spiked tail, and massive
+    wings. They wield a flaming fork and rule with terror and cruelty.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Impenetrable Hide
+    - speech. Telepathy
+  moves:
+    - Flaming Fork
+    - Hellfire Bolt
+    - Festering Wound
+  desires:
+    - value: to be both revered and feared.
+      are: false
+    - value: to be forced into any compromise.
+      are: false
+  sensories:
+    colors:
+      - name: Fiery Red
+        color: '#b22222'
+      - name: Burnt Orange
+        color: '#cc5600'
+      - name: Deep Black
+        color: '#1c1c1c'
+    sights: stretching horn shadows, gleaming fork, stab wounds
+    sounds: resonant telepathic voice, malevolent chuckles
+    smells: acrid sulfur, suffocating smoke, brimstone
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Broken summoning circles ...
+      instructions: ''
+      table:
+        - - In a temple by a priest who lost their faith.
+          - In a farmhouse by a grief-stricken mother.
+          - In a tower by a wizard consumed with jealousy.
+          - In the study of a hero haunted by failure.
+          - In a tavern by a minstrel obsessed with fame.
+          - In a cobbler's cellar, by a long-held prisoner.
+prototypeToken:
+  name: Devil, Horned
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368369741
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: BEaokrIlmFWOSoVk
+sort: 1400000
+_key: '!actors!BEaokrIlmFWOSoVk'
+

--- a/src/packs/monsters/Devil__Imp_xiTJHrnx89mGnxTN.yml
+++ b/src/packs/monsters/Devil__Imp_xiTJHrnx89mGnxTN.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Devil, Imp
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Tiny, winged fiends driven by trickery and chaos. They delight in sowing
+    mischief and confusion, stinging with mind-warping venoms before
+    vanishing.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Compulsive Mischief
+    - Invisibility-At-Will
+    - Speech, Telepathy
+  moves:
+    - Venomous Sting
+    - Vermin Form
+    - Enchant Item
+  desires:
+    - value: to sew subtle seeds of chaos.
+      are: false
+    - value: to be confronted directly, ruining the surprise.
+      are: false
+  sensories:
+    colors:
+      - name: Wicked Red
+        color: '#8b0101'
+      - name: Tarnished Gold
+        color: '#a57c00'
+      - name: Smoky Gray
+        color: '#696969'
+    sights: quick flash of movement, clawed footprints
+    sounds: buzz of wings, eerie silence, lingering snickering
+    smells: faint whiffs of venom and sulfur
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Impish Snares
+      instructions: ''
+      table:
+        - - Spoon that makes food taste slightly rotten.
+          - Quill that weaves insults into messages.
+          - Candle that goes out at the worst time.
+          - Map that shifts landmarks and roads.
+          - Compass that always points towards fun.
+          - Doll that moves to a new spot each night.
+prototypeToken:
+  name: Devil, Imp
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368370571
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: xiTJHrnx89mGnxTN
+sort: 1500000
+_key: '!actors!xiTJHrnx89mGnxTN'
+

--- a/src/packs/monsters/Dire_Bear_GsZvTAh6Vhk7SNIE.yml
+++ b/src/packs/monsters/Dire_Bear_GsZvTAh6Vhk7SNIE.yml
@@ -1,0 +1,148 @@
+name: Dire Bear
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fiercely territorial, collosal animals with thick fur and enormous claws.
+    It responds viciously to any intrusion into its territory.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Dense Fur
+    - Surprising Speed
+  moves:
+    - Testing Charge
+    - Bellowing Roar
+    - Mauling Grapple
+  desires:
+    - value: to foster the next generation of new rulers.
+      are: false
+    - value: for its boundaries to be broken.
+      are: false
+  sensories:
+    colors:
+      - name: Deep Brown
+        color: '#371c06'
+      - name: Furry Black
+        color: '#221c1c'
+      - name: Grizzly Brown
+        color: '#623d09'
+    sights: snapped trees, breath steaming in the cold air
+    sounds: deafening roar echoing, pounding footsteps
+    smells: crisp pine, overturnt earth, wet fur.
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Territory Woes
+      instructions: ''
+      table:
+        - - It has far too many cuby.
+          - Grand hunt has been called for it.
+          - Another dire apex predator has arrived.
+          - Civilization encroaches on its borders.
+          - Totemic wards restrict its roaming grounds.
+          - Goblins wage war against orcs in its lands.
+prototypeToken:
+  name: Dire Bear
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: null
+  bar2:
+    attribute: null
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 0
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+folder: null
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368371339
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: GsZvTAh6Vhk7SNIE
+sort: 1600000
+_key: '!actors!GsZvTAh6Vhk7SNIE'
+

--- a/src/packs/monsters/Dire_Centipede_mtNH98nx4OUgxgcP.yml
+++ b/src/packs/monsters/Dire_Centipede_mtNH98nx4OUgxgcP.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Dire Centipede
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Gigantic, armored insects with venomous pincers and countless legs. They
+    skitter through dark tunnels, creating a labyrinthine network of hunting
+    grounds.</p>
+  notes: ''
+  role: skirmisher
+  tier: tough
+  traits:
+    - Cling to Walls
+    - Terrifying Speed
+  moves:
+    - Warning Hiss
+    - Drop Down
+    - Snip Off Limbs
+  desires:
+    - value: to expand its labyrinth of tunnels.
+      are: false
+    - value: bright light or loud noises.
+      are: false
+  sensories:
+    colors:
+      - name: Burnt Sienna
+        color: '#e97451'
+      - name: Earthy Brown
+        color: '#8b4512'
+      - name: Chitin Black
+        color: '#2f2f2f'
+    sights: endlessly writhing legs, shining chitin, twitching pincers
+    sounds: rhythmic clicking, sharp hiss, unsettling rustling
+    smells: nutty insect aroma, sour rotting wood
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Home Tunnels
+      instructions: ''
+      table:
+        - - Tunnels filled with towering mushrooms.
+          - The ruins of a lavish underground palace.
+          - Enormous cavern full of bioluminescence.
+          - Through the bones of a buried giant.
+          - Flooded sea caves, where it hunts for sharks.
+          - Through twisting roots of colossal trees.
+prototypeToken:
+  name: Dire Centipede
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368373777
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: mtNH98nx4OUgxgcP
+sort: 1700000
+_key: '!actors!mtNH98nx4OUgxgcP'
+

--- a/src/packs/monsters/Dire_Crab_Objnybu85VIrzcB4.yml
+++ b/src/packs/monsters/Dire_Crab_Objnybu85VIrzcB4.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Dire Crab
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering crustaceans with enormous crushing claws, only vulnerable when
+    they molt. They scuttle along coastal shallows, devouring anything in their
+    path.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Impenetrable Shell
+    - Voracious Appetites
+  moves:
+    - Click, Clack
+    - Snip, Snap
+    - Rip In Half
+  desires:
+    - value: its offspring to overrun the beaches.
+      are: false
+    - value: for anything to get under it.
+      are: false
+  sensories:
+    colors:
+      - name: Shell Red
+        color: '#b22222'
+      - name: Coral Pink
+        color: '#ff7f50'
+      - name: Fleshy Orange
+        color: '#ffa07a'
+    sights: boulders clipped in half, odd holes in the sand
+    sounds: creak of its shell grinding, clicking of legs
+    smells: wet sand, seaweed, and decaying marine life
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Dire Hermit Crab Shells
+      instructions: ''
+      table:
+        - - Sunken pirate ship, now haunted.
+          - Fallen castle turret, filled with explosives.
+          - Giant's skull, with a gleaming gold tooth.
+          - Whale ribcage, covered in barnacles.
+          - Gnomish submarine, still water-tight.
+          - Iron cauldron once used by a giant.
+prototypeToken:
+  name: Dire Crab
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368375072
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: Objnybu85VIrzcB4
+sort: 1800000
+_key: '!actors!Objnybu85VIrzcB4'
+

--- a/src/packs/monsters/Dire_Crocodile_p4mBcLAnflawBka5.yml
+++ b/src/packs/monsters/Dire_Crocodile_p4mBcLAnflawBka5.yml
@@ -1,0 +1,147 @@
+folder: null
+name: Dire Crocodile
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Enormous reptiles with iron-like scales and jagged maws. They lurk in
+    wait in murky waters, virtually imperceptible until they move.</p>
+  notes: ''
+  role: lurker
+  tier: tough
+  traits:
+    - Swampy Camouflage
+  moves:
+    - Snapping Lunge
+    - Death Roll
+    - Drown Prey
+  desires:
+    - value: to eat anything that comes close.
+      are: false
+    - value: to move when unnecessary.
+      are: false
+  sensories:
+    colors:
+      - name: Swamp Green
+        color: '#566b30'
+      - name: Muddy Brown
+        color: '#8b4512'
+      - name: Scaly Black
+        color: '#2f2f2f'
+    sights: massive eyes above the waterline, still waters
+    sounds: scraping of belly on ground, thrashing water
+    smells: mud and algae, stagnant swamp water
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Worshippers (the cro's unaware)
+      instructions: ''
+      table:
+        - - Local fishers, who see it as the god of floods.
+          - Cultists, who offer sacrifices.
+          - Water elementals, believing it guards the river.
+          - Merfolk, who live alongside it.
+          - Hill giants, envious of its eternal hunger.
+          - Swamp hags, believing it gives them magic.
+prototypeToken:
+  name: Dire Crocodile
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368376525
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: p4mBcLAnflawBka5
+sort: 2000000
+_key: '!actors!p4mBcLAnflawBka5'
+

--- a/src/packs/monsters/Dire_Eagle_zRXbJjV3o7htvUDP.yml
+++ b/src/packs/monsters/Dire_Eagle_zRXbJjV3o7htvUDP.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Dire Eagle
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Vast raptors with massive wingspans and razor-sharp talons. They soar
+    from high cliffs and dive with deadly precision and perfect timing to bring
+    down prey.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Keen Eyesight
+    - Extremely Swift
+  moves:
+    - Plunging Strike
+    - Swooping Snatch
+    - Piercing Cry
+  desires:
+    - value: other predators to see and fear it.
+      are: false
+    - value: anything coming near its nest.
+      are: false
+  sensories:
+    colors:
+      - name: Feathery White
+        color: '#d3d3d3'
+      - name: Earthy Brown
+        color: '#654320'
+      - name: Stormy Gray
+        color: '#696969'
+    sights: huge falling feather, talon gouges in the earth
+    sounds: whoosh of massive wings, rustling of feathers
+    smells: crisp high-altitude air, faint carrion scent
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unique Eyries
+      instructions: ''
+      table:
+        - - Spire of a still-occupied wizard's tower.
+          - Atop a giant redwood tree, the tallest in the world.
+          - Rocky outcrop above a foggy elephant graveyard.
+          - Desolate mesatop, bones surrounding the nest.
+          - Between the stone arches of an ancient bridge.
+          - In the hand of an enormous carved statue.
+prototypeToken:
+  name: Dire Eagle
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368379608
+  modifiedTime: 1750368379620
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: zRXbJjV3o7htvUDP
+sort: 1900000
+_key: '!actors!zRXbJjV3o7htvUDP'
+

--- a/src/packs/monsters/Dire_Shark_u4Er2uzsQrPmNFXX.yml
+++ b/src/packs/monsters/Dire_Shark_u4Er2uzsQrPmNFXX.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Dire Shark
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive beasts of the ocean's depth, with rows of serrated teeth and a
+    sleek, powerful body. They prowl the seas, always in search of sizable
+    prey</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Blends Into The Depths
+    - Knows No Fear
+  moves:
+    - From The Depths
+    - Frenzied Thrash
+    - Bite Off A Chunk
+  desires:
+    - value: to instill deep fear long before it strikes.
+      are: false
+    - value: for ships to operate in its waters.
+      are: false
+  sensories:
+    colors:
+      - name: Ocean Gray
+        color: '#7a899c'
+      - name: Bone White
+        color: '#d7d4c5'
+      - name: Deep Blue
+        color: '#254e86'
+    sights: patch of red-stained ocean, ominous dorsal fin
+    sounds: heavy thud hitting the ship, eerie silence
+    smells: briny saltwater, upturned seawater
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Destroyed Ships
+      instructions: ''
+      table:
+        - - Royal flagship, crown jewels still aboard.
+          - War galleon, with the spoils of war.
+          - Passenger liner, still barely floating.
+          - Submarine, the survivors in a deep sea cave.
+          - Ghost ship, having cursed the waters for decades.
+          - Orcish warship, fused to its back by dark magic.
+prototypeToken:
+  name: Dire Shark
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368381470
+  modifiedTime: 1750368381470
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: u4Er2uzsQrPmNFXX
+sort: 0
+_key: '!actors!u4Er2uzsQrPmNFXX'
+

--- a/src/packs/monsters/Dire_Spider_MwOjdYWU5z72Aa6w.yml
+++ b/src/packs/monsters/Dire_Spider_MwOjdYWU5z72Aa6w.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Dire Spider
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Monstrously huge arachnids with legs like tree trunks and venomous fangs.
+    They spin vast webs coating entire areas or drop from enormous heights on
+    prey</p>
+  notes: ''
+  role: tactician
+  tier: tough
+  traits:
+    - Vibration Sense
+    - Complex Webbing
+  moves:
+    - Surprise Drop
+    - Venomous Bite
+    - Wrap Prey
+  desires:
+    - value: to always have enough food for later.
+      are: false
+    - value: to be anywhere near fire.
+      are: false
+  sensories:
+    colors:
+      - name: Venom Green
+        color: '#566b30'
+      - name: Midnight Black
+        color: '#060505'
+      - name: Dark Crimson
+        color: '#8b0101'
+    sights: thick silk strands, barely visible in shadow, thick hairs
+    sounds: unsettling skitter, eerie silence, soft thud, slurping
+    smells: sickly-sweet venom, putrid wrapped bodies
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Dire Spider Varieties
+      instructions: ''
+      table:
+        - - Netcaster, trapping from far away.
+          - Jumping, catching prey off-guard with a leap.
+          - Longlegs, moving quickly through foliage.
+          - Pitdweller, striking from well-hidden holes.
+          - Waterglider, skimming across marshes.
+          - Divingbell, living completely underwater.
+prototypeToken:
+  name: Dire Spider
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368382202
+  modifiedTime: 1750368382202
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: MwOjdYWU5z72Aa6w
+sort: 0
+_key: '!actors!MwOjdYWU5z72Aa6w'
+

--- a/src/packs/monsters/Dire_Wolf_kt373vHvqRplqfox.yml
+++ b/src/packs/monsters/Dire_Wolf_kt373vHvqRplqfox.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Dire Wolf
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Hulking wolf with bristling fur and dagger-like fangs. They hunt with a
+    pack of lesser wolves, using fearsome coordination to trap and bring down
+    prey.</p>
+  notes: ''
+  role: overseer
+  tier: tough
+  traits:
+    - Relentless Pursuer
+    - Pack Coordination
+  moves:
+    - Call Pack
+    - Tackle Prey
+    - Pack Attack
+  desires:
+    - value: to protect its pack.
+      are: false
+    - value: anything that prevents it from roaming free.
+      are: false
+  sensories:
+    colors:
+      - name: Ashen Gray
+        color: '#696969'
+      - name: Light Brown
+        color: '#8b5f3c'
+      - name: Frosty Gray
+        color: '#c0c0c0'
+    sights: silhouette at edge of clearing, tracks in the mud
+    sounds: haunting howl, guttural growl, heavy breathing
+    smells: fur mixed with fresh earth, sweat, mountain air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Lunar behaviours
+      instructions: ''
+      table:
+        - - New moon, restless border patrols.
+          - Crescent, young grow unruly.
+          - Full moon, deafening howls.
+          - Gibbous, pack dominance shifts.
+          - Blood moon, rampage outside their borders.
+          - Blue moon, dire wolf litter is born.
+prototypeToken:
+  name: Dire Wolf
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368382992
+  modifiedTime: 1750368382992
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: kt373vHvqRplqfox
+sort: 0
+_key: '!actors!kt373vHvqRplqfox'
+

--- a/src/packs/monsters/Dislocation_Beast_qlcR5xSomvJvV23P.yml
+++ b/src/packs/monsters/Dislocation_Beast_qlcR5xSomvJvV23P.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Dislocation Beast
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Elusive, panther-like creatures with six legs and barbed tentacles. They
+    warp reality to disorient and confuse, blending into their surroundings.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Phantom Forms
+    - Ethereal Agility
+  moves:
+    - Tentacle Swipes
+    - Disorienting Blurs
+    - Sudden Pounce
+  desires:
+    - value: to swiftly harness the chaos it creates.
+      are: false
+    - value: to ever put itself in danger.
+      are: false
+  sensories:
+    colors:
+      - name: Shadow Black
+        color: '#2f2f2f'
+      - name: Midnight Blue
+        color: '#19196f'
+      - name: Mystic Purple
+        color: '#6e498c'
+    sights: shifting blurs, disrupted reality, phantom images
+    sounds: distorted growl, strange echoes, swish of movement
+    smells: spicy musk, sharply cut aromas, caustic undertone
+  pool:
+    diceNum: 6
+    max: null
+  tables:
+    - name: Bizarre Phenomena
+      instructions: ''
+      table:
+        - - Mundane sounds, completely out of place.
+          - Fleeting reflections from alternate worlds.
+          - Shadows elongate unnaturally and linger.
+          - Echoes ricochet unpredictably.
+          - Colors bleed into neighboring hues.
+          - Invisible ripples that distort vision.
+prototypeToken:
+  name: Dislocation Beast
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: null
+  bar2:
+    attribute: null
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 0
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368383948
+  modifiedTime: 1750368383948
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: qlcR5xSomvJvV23P
+sort: 0
+_key: '!actors!qlcR5xSomvJvV23P'
+

--- a/src/packs/monsters/Doppelganger_o8DARi7C5xH9AwWE.yml
+++ b/src/packs/monsters/Doppelganger_o8DARi7C5xH9AwWE.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Doppelganger
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Shapeshifting figures with gray, featureless skin. They can perfectly
+    mimic any humanoid, infiltrating societies to achieve their own mysterious
+    goals.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Shapechanger
+    - Mindreader
+    - Speech, Telepathy
+  moves:
+    - Shift Appearance
+    - Mental Probe
+    - Psychic Scream
+  desires:
+    - value: to experience new lives.
+      are: false
+    - value: its true form to be seen.
+      are: false
+  sensories:
+    colors:
+      - name: Neutral Gray
+        color: '#7a7d82'
+      - name: ''
+        color: null
+      - name: ''
+        color: null
+    sights: shifting facial features, subtle posture changes
+    sounds: disconcerting silence, soft self-reprimanding
+    smells: a smell fully unexpected of that person
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Identities you know
+      instructions: ''
+      table:
+        - - Noble's trusted advisor, met last winter.
+          - The second-to-last person the PCs met.
+          - Old flame of a PC, thought long dead.
+          - Wandering monk, seen only days ago.
+          - Previous PC, from this campaign or another.
+          - Executed thief, now walking free.
+prototypeToken:
+  name: Doppelganger
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368384874
+  modifiedTime: 1750368384874
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: o8DARi7C5xH9AwWE
+sort: 0
+_key: '!actors!o8DARi7C5xH9AwWE'
+

--- a/src/packs/monsters/Dragon_ODpeQ7mgQAoIV8M6.yml
+++ b/src/packs/monsters/Dragon_ODpeQ7mgQAoIV8M6.yml
@@ -1,0 +1,378 @@
+folder: null
+name: Dragon
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Acid
+    type: challenge
+    _id: kROMYVpRVv7sMdnz
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits: []
+      moves:
+        - Caustic Pools
+        - Corrode Armor
+        - Eat Away Stone
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ODpeQ7mgQAoIV8M6.kROMYVpRVv7sMdnz'
+  - name: Lightning
+    type: challenge
+    _id: VC2KWPJEzVKd7mq4
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits: []
+      moves:
+        - Chained Stun
+        - Disable Machine
+        - Thunder Roar
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ODpeQ7mgQAoIV8M6.VC2KWPJEzVKd7mq4'
+  - name: Cold
+    type: challenge
+    _id: f20aa0akSO6OlPWG
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits: []
+      moves:
+        - Ice Wall
+        - Freeze in Place
+        - Slow movement
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ODpeQ7mgQAoIV8M6.f20aa0akSO6OlPWG'
+  - name: Poison
+    type: challenge
+    _id: pq61xMmWuTGft4b3
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits: []
+      moves:
+        - Confusion
+        - Force Wretching
+        - Lingering Cloud
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ODpeQ7mgQAoIV8M6.pq61xMmWuTGft4b3'
+  - name: Fire
+    type: challenge
+    _id: 3ncdhDHn8vOXzz8q
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits: []
+      moves:
+        - Burn Barriers
+        - Melt Weapons
+        - Smoke Screen
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ODpeQ7mgQAoIV8M6.3ncdhDHn8vOXzz8q'
+  - name: Necrosis
+    type: challenge
+    _id: Psb1XoGMJuezQf8v
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits: []
+      moves:
+        - Deathly Fear
+        - Life Drain
+        - Wither Plants
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ODpeQ7mgQAoIV8M6.Psb1XoGMJuezQf8v'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368386078
+  modifiedTime: 1750368386078
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: ODpeQ7mgQAoIV8M6
+sort: 0
+_key: '!actors!ODpeQ7mgQAoIV8M6'
+

--- a/src/packs/monsters/Dragon__Acid_ziFPco3DR7SWjFnX.yml
+++ b/src/packs/monsters/Dragon__Acid_ziFPco3DR7SWjFnX.yml
@@ -1,0 +1,188 @@
+folder: null
+name: Dragon, Acid
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: null
+  bar2:
+    attribute: null
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 0
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Acid
+    type: challenge
+    _id: kROMYVpRVv7sMdnz
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Caustic Pools
+        - Corrode Armor
+        - Eat Away Stone
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ziFPco3DR7SWjFnX.kROMYVpRVv7sMdnz'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368387154
+  modifiedTime: 1750368387154
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: ziFPco3DR7SWjFnX
+sort: 0
+_key: '!actors!ziFPco3DR7SWjFnX'
+

--- a/src/packs/monsters/Dragon__Cold_FgHLbqsBVkwZjhoT.yml
+++ b/src/packs/monsters/Dragon__Cold_FgHLbqsBVkwZjhoT.yml
@@ -1,0 +1,188 @@
+folder: null
+name: Dragon, Cold
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Cold
+    type: challenge
+    _id: f20aa0akSO6OlPWG
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Ice Wall
+        - Freeze in Place
+        - Slow movement
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!FgHLbqsBVkwZjhoT.f20aa0akSO6OlPWG'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368388077
+  modifiedTime: 1750368388077
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: FgHLbqsBVkwZjhoT
+sort: 0
+_key: '!actors!FgHLbqsBVkwZjhoT'
+

--- a/src/packs/monsters/Dragon__Fire_LTng51WCMn0pvIQp.yml
+++ b/src/packs/monsters/Dragon__Fire_LTng51WCMn0pvIQp.yml
@@ -1,0 +1,188 @@
+folder: null
+name: Dragon, Fire
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Fire
+    type: challenge
+    _id: 3ncdhDHn8vOXzz8q
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Burn Barriers
+        - Melt Weapons
+        - Smoke Screen
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!LTng51WCMn0pvIQp.3ncdhDHn8vOXzz8q'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368391082
+  modifiedTime: 1750368391082
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: LTng51WCMn0pvIQp
+sort: 0
+_key: '!actors!LTng51WCMn0pvIQp'
+

--- a/src/packs/monsters/Dragon__Lightning_nU3Ck4k0yMdOXIiO.yml
+++ b/src/packs/monsters/Dragon__Lightning_nU3Ck4k0yMdOXIiO.yml
@@ -1,0 +1,188 @@
+folder: null
+name: Dragon, Lightning
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Lightning
+    type: challenge
+    _id: VC2KWPJEzVKd7mq4
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Chained Stun
+        - Disable Machine
+        - Thunder Roar
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!nU3Ck4k0yMdOXIiO.VC2KWPJEzVKd7mq4'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368391962
+  modifiedTime: 1750368391962
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: nU3Ck4k0yMdOXIiO
+sort: 0
+_key: '!actors!nU3Ck4k0yMdOXIiO'
+

--- a/src/packs/monsters/Dragon__Necrosis_GLfevxkrZMMW4wva.yml
+++ b/src/packs/monsters/Dragon__Necrosis_GLfevxkrZMMW4wva.yml
@@ -1,0 +1,188 @@
+folder: null
+name: Dragon, Necrosis
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Necrosis
+    type: challenge
+    _id: Psb1XoGMJuezQf8v
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Deathly Fear
+        - Life Drain
+        - Wither Plants
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!GLfevxkrZMMW4wva.Psb1XoGMJuezQf8v'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368392900
+  modifiedTime: 1750368392900
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: GLfevxkrZMMW4wva
+sort: 0
+_key: '!actors!GLfevxkrZMMW4wva'
+

--- a/src/packs/monsters/Dragon__Poison_n9dU9RmqMp7sb0jQ.yml
+++ b/src/packs/monsters/Dragon__Poison_n9dU9RmqMp7sb0jQ.yml
@@ -1,0 +1,188 @@
+folder: null
+name: Dragon, Poison
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, scaled beasts with wings and elemental breath attacks. They
+    hoard treasures and instill deep, instinctual fears as a top apex
+    predator.</p>
+  notes: <p></p>
+  role: blaster
+  tier: tough
+  traits:
+    - Frightful Presence
+    - Ancient Memories
+    - Speech
+  moves:
+    - Elemental Breath
+    - Wing Buffet
+    - Chomp Down
+  desires:
+    - value: to assert its supremacy over all.
+      are: false
+    - value: to be humbled in any way.
+      are: false
+  sensories:
+    colors:
+      - name: Scale Emerald
+        color: '#4f7251'
+      - name: Crimson Flame
+        color: '#8b0101'
+      - name: Gold Accent
+        color: '#daa521'
+    sights: massive features, self-important posture
+    sounds: thunderous roar, wings beating, intake of breath
+    smells: faint scent of gold and ancient relics
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Hoarding instincts
+      instructions: besides gold
+      table:
+        - - Scrolls filled with lost languages.
+          - Crown jewels of forgotten kingdoms.
+          - Gravestones of great heroes.
+          - Maps of the world.
+          - Weapons forged in time of great need.
+          - Holy symbols of fallen gods.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Poison
+    type: challenge
+    _id: pq61xMmWuTGft4b3
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Confusion
+        - Force Wretching
+        - Lingering Cloud
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!n9dU9RmqMp7sb0jQ.pq61xMmWuTGft4b3'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368394035
+  modifiedTime: 1750368394035
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: n9dU9RmqMp7sb0jQ
+sort: 0
+_key: '!actors!n9dU9RmqMp7sb0jQ'
+

--- a/src/packs/monsters/Elemental__Air_TYyXy93gKMFPcboi.yml
+++ b/src/packs/monsters/Elemental__Air_TYyXy93gKMFPcboi.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Elemental, Air
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Swirling masses of wind and cloud that can change shape. They represent
+    the raw power of storms and wind, mercurial and unpredictable.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Cyclonic Form
+    - Untouchable
+    - Speech
+  moves:
+    - Gale Force
+    - Whirlwind
+    - Suffocate
+  desires:
+    - value: to flow ever free.
+      are: false
+    - value: to be ignored.
+      are: false
+  sensories:
+    colors:
+      - name: Cloud White
+        color: '#e3e6eb'
+      - name: Sky Blue
+        color: '#a4c5e4'
+      - name: Whisper Gray
+        color: '#a9a9a9'
+    sights: leaves and debris swirling, dust and sand kicked up
+    sounds: howling wind, rush of air, whistling gusts
+    smells: high-altitude winds, rain and freshly turned earth
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Form & Personality
+      instructions: ''
+      table:
+        - - Swirling cyclone, erratic and wild.
+          - Floating cloud, serene and evasive.
+          - Tornado, furious and unstoppable.
+          - Dust devil, sneaky and persistent.
+          - Gusty winds, playful and mischievous.
+          - Zephyr, kind but undependable.
+prototypeToken:
+  name: Elemental, Air
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368394928
+  modifiedTime: 1750368394928
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: TYyXy93gKMFPcboi
+sort: 0
+_key: '!actors!TYyXy93gKMFPcboi'
+

--- a/src/packs/monsters/Elemental__Earth_3P4eBW2Oadfp5ESk.yml
+++ b/src/packs/monsters/Elemental__Earth_3P4eBW2Oadfp5ESk.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Elemental, Earth
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, rock-like creatures embodying the raw strength of the earth.
+    They're slow but nearly unstoppable, lumbering through anything in their
+    way</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Rock-solid
+    - Tremor Sense
+    - Speech
+  moves:
+    - Earthquake
+    - Stone Spires
+    - Boulder Toss
+  desires:
+    - value: to endure beyond time.
+      are: false
+    - value: for its form to be chipped away.
+      are: false
+  sensories:
+    colors:
+      - name: Mossy Green
+        color: '#566b30'
+      - name: Rocky Brown
+        color: '#8b4512'
+      - name: Stone Gray
+        color: '#696969'
+    sights: ground trembling, boulders rolling, spikes of stone
+    sounds: rumbling groans, deafening crack of rocks, thumps
+    smells: loamy disturbed soil, moss, wet stone, mineral tang
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Biome & Personality
+      instructions: ''
+      table:
+        - - Forest, rooted and protective.
+          - Badlands, harsh and unforgiving.
+          - Mountains, proud and resilient.
+          - Caves, brooding and watchful.
+          - Mudflats, slow but determined.
+          - Grasslands, patient and enduring.
+prototypeToken:
+  name: Elemental, Earth
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368395695
+  modifiedTime: 1750368395695
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 3P4eBW2Oadfp5ESk
+sort: 0
+_key: '!actors!3P4eBW2Oadfp5ESk'
+

--- a/src/packs/monsters/Elemental__Fire_g2C1SByOOmGmgHT8.yml
+++ b/src/packs/monsters/Elemental__Fire_g2C1SByOOmGmgHT8.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Elemental, Fire
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Constantly shifting infernos that consume everything in their path. They
+    blaze with insatiable hunger, leaving behind smoldering ash and molten
+    ruin.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Blazing Aura
+    - Insatiable Hunger
+    - Speech
+  moves:
+    - Flame Lash
+    - Melt Metals
+    - Summon Firelings
+  desires:
+    - value: to consume and move on.
+      are: false
+    - value: to let embers die out.
+      are: false
+  sensories:
+    colors:
+      - name: Blazing Red
+        color: '#b22222'
+      - name: Burnt Gold
+        color: '#b8860b'
+      - name: Molten Orange
+        color: '#ff4500'
+    sights: roiling mass, flickering edges, glowing embers
+    sounds: crackle and pop, roaring, hum of molten metals
+    smells: sulfur, brimstone, smoke, char, tang of metals
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Ignition & Personality
+      instructions: ''
+      table:
+        - - Lightning strike, violent and ephemeral.
+          - Ritual flame, sacred and commanding.
+          - Forge fire, controlled and powerful.
+          - Coal embers, patient and smoldering.
+          - Wildfire, ravenous and unrestrained.
+          - Funeral pyre, solemn and determined.
+prototypeToken:
+  name: Elemental, Fire
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368397331
+  modifiedTime: 1750368397331
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: g2C1SByOOmGmgHT8
+sort: 0
+_key: '!actors!g2C1SByOOmGmgHT8'
+

--- a/src/packs/monsters/Elemental__Water_7o0lsLoqjlFGDO7G.yml
+++ b/src/packs/monsters/Elemental__Water_7o0lsLoqjlFGDO7G.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Elemental, Water
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fluid, amorphous entities resembling a wave or torrent. They represent
+    the relentless and ever-changing nature of water, adaptable and hard to
+    contain.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Turbulent Shape
+    - Rushing Flow
+    - Speech
+  moves:
+    - Undertow
+    - Surge
+    - Whirlpool
+  desires:
+    - value: to flow along channels towards growth.
+      are: false
+    - value: to lose touch with the ground.
+      are: false
+  sensories:
+    colors:
+      - name: Ocean Blue
+        color: '#5989c9'
+      - name: Wavecrest White
+        color: '#d9e4ea'
+      - name: Seafoam Green
+        color: '#88a891'
+    sights: crashing waters, churning currents, glistening tendrils
+    sounds: roar of waves, splashing, sloshing, bubbling, gurgling
+    smells: briny ocean, soaked soil, sharp freshwater
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Water Source & Personality
+      instructions: ''
+      table:
+        - - Tidal pool, playful and fickle.
+          - Raging rapids, relentless and reckless.
+          - Murky swamp, deceptive and suffocating.
+          - Rain, gentle and melancholic.
+          - Geyser, frustrated and volatile.
+          - Oasis, welcoming and mysterious.
+prototypeToken:
+  name: Elemental, Water
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368398326
+  modifiedTime: 1750368398326
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 7o0lsLoqjlFGDO7G
+sort: 0
+_key: '!actors!7o0lsLoqjlFGDO7G'
+

--- a/src/packs/monsters/Ettercap_0i8IJgOEEpJObYmy.yml
+++ b/src/packs/monsters/Ettercap_0i8IJgOEEpJObYmy.yml
@@ -1,0 +1,378 @@
+folder: null
+name: Ettercap
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Hunched, two-legged spider-like creature with web-spinning claws. They
+    lurk within a maze of webbed traps and often control huge spider
+    colonies.</p>
+  notes: ''
+  role: tactician
+  tier: tough
+  traits:
+    - Clever Silk Traps
+    - Clings To Walls
+    - Speech (Rarely)
+  moves:
+    - Sling Webbing
+    - Venomous Bite
+    - Web Skitter
+  desires:
+    - value: to never face danger directly.
+      are: false
+    - value: for its hard work webbing to be destroyed.
+      are: false
+  sensories:
+    colors:
+      - name: Spider Gray
+        color: '#808080'
+      - name: Venom Purple
+        color: '#6c4c7d'
+      - name: Forest Green
+        color: '#495d3a'
+    sights: webs between trees, struggling victims, shiny fangs
+    sounds: faint skitter of legs, whirr of web-spinning
+    smells: rotting wood, wet earth, decaying bodies
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Webbed Domains
+      instructions: ''
+      table:
+        - - Bramble patch, every inch covered in webs.
+          - Long, narrow, winding canyons.
+          - Massive, abandoned library in the capital.
+          - Granaries abandoned during the famine.
+          - Derelict shipwreck, sails webbed over.
+          - Sunken pitfall in the middle of the woods.
+prototypeToken:
+  name: Ettercap
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Alarm Stands
+    type: challenge
+    _id: 5YlWvrIEnYY3mlEY
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Nearly invisible
+      moves:
+        - Startled Spider
+        - Another victim
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!0i8IJgOEEpJObYmy.5YlWvrIEnYY3mlEY'
+  - name: Holding Traps
+    type: challenge
+    _id: RMCNsi31iDtU8jT1
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Incredibly sticky
+      moves:
+        - Ensnaring Pull
+        - Tangling Webs
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!0i8IJgOEEpJObYmy.RMCNsi31iDtU8jT1'
+  - name: Deadly Traps
+    type: challenge
+    _id: eXQ6apVjSPhWG2Ln
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Serrated webbing
+      moves:
+        - Neck Slice
+        - Constricting Web
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!0i8IJgOEEpJObYmy.eXQ6apVjSPhWG2Ln'
+  - name: Cocoons
+    type: challenge
+    _id: IgOlri1qvYxhBha8
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Wriggling Victims
+      moves:
+        - Desperate Pleas
+        - Horrific Feasting
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!0i8IJgOEEpJObYmy.IgOlri1qvYxhBha8'
+  - name: Spider Nest
+    type: challenge
+    _id: 0Z4BcKOask7goYX4
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Rabbit-sized Spiders
+      moves:
+        - Split Up Prey
+        - Biting Frenzy
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!0i8IJgOEEpJObYmy.0Z4BcKOask7goYX4'
+  - name: Ettercap
+    type: challenge
+    _id: rl2OE93IgTTURNpJ
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Can appear anytime
+      moves:
+        - Lethal Bite
+        - Flee To Safety
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!0i8IJgOEEpJObYmy.rl2OE93IgTTURNpJ'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368401053
+  modifiedTime: 1750368401053
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 0i8IJgOEEpJObYmy
+sort: 0
+_key: '!actors!0i8IJgOEEpJObYmy'
+

--- a/src/packs/monsters/Ettin__Hootfang___Foulhorn_OnRnwc2YPJ5FWRSJ.yml
+++ b/src/packs/monsters/Ettin__Hootfang___Foulhorn_OnRnwc2YPJ5FWRSJ.yml
@@ -1,0 +1,227 @@
+folder: null
+name: Ettin, Hootfang & Foulhorn
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering, two-headed figure with mismatched weapons. They lumber through
+    the wilderness, both heads bickering endlessly about trivial matters.</p>
+  notes: >-
+    <p>To pass an ettin without a fight, you'll need to persuade both heads.
+    Remember, they're dim and don't get along</p>
+  role: brute
+  tier: tough
+  traits:
+    - Constantly Bickering
+    - Clumsy Stride
+    - Speech
+  moves:
+    - Swing Weapons
+    - Headbutts
+    - Dual Shouting
+  desires:
+    - value: simple pleasures both heads can agree on.
+      are: false
+    - value: to do anything that requires precision.
+      are: false
+  sensories:
+    colors:
+      - name: Fleshy Gray
+        color: '#a9a9a9'
+      - name: Dark Leather
+        color: '#4b3621'
+      - name: Ashen White
+        color: '#e3e0d1'
+    sights: chaotic movements, dragging feet, frustrated glaring
+    sounds: constant bickering, clumsy thuds, mismatched words
+    smells: sweaty musk, animal hides, unkempt hair
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unlikely Protector of ...
+      instructions: ''
+      table:
+        - - Three old witches, who use it as a bodyguard.
+          - Ragtag group of orphans that saved it.
+          - Goblins, because they worship it as a god.
+          - Hamlet of farmers, who feed it.
+          - Wandering circus, using it as a bouncer.
+          - Hermit, friends with both heads.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Hootfang
+    type: challenge
+    _id: 3ncdhDHn8vOXzz8q
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Flamboyant, selfish
+        - Seeks real praise
+        - Reacts to boredom
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!OnRnwc2YPJ5FWRSJ.3ncdhDHn8vOXzz8q'
+  - name: Foulhorn
+    type: challenge
+    _id: Psb1XoGMJuezQf8v
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Quiet, manipulative
+        - Seeks to swindle
+        - Reacts to confusion
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!OnRnwc2YPJ5FWRSJ.Psb1XoGMJuezQf8v'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368402892
+  modifiedTime: 1750368402892
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: OnRnwc2YPJ5FWRSJ
+sort: 0
+_key: '!actors!OnRnwc2YPJ5FWRSJ'
+

--- a/src/packs/monsters/Ettin__Runejaw___Goldmaw_KkFsnYfldYWfUGwp.yml
+++ b/src/packs/monsters/Ettin__Runejaw___Goldmaw_KkFsnYfldYWfUGwp.yml
@@ -1,0 +1,227 @@
+folder: null
+name: Ettin, Runejaw & Goldmaw
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering, two-headed figure with mismatched weapons. They lumber through
+    the wilderness, both heads bickering endlessly about trivial matters.</p>
+  notes: >-
+    <p>To pass an ettin without a fight, you'll need to persuade both heads.
+    Remember, they're dim and don't get along</p>
+  role: brute
+  tier: tough
+  traits:
+    - Constantly Bickering
+    - Clumsy Stride
+    - Speech
+  moves:
+    - Swing Weapons
+    - Headbutts
+    - Dual Shouting
+  desires:
+    - value: simple pleasures both heads can agree on.
+      are: false
+    - value: to do anything that requires precision.
+      are: false
+  sensories:
+    colors:
+      - name: Fleshy Gray
+        color: '#a9a9a9'
+      - name: Dark Leather
+        color: '#4b3621'
+      - name: Ashen White
+        color: '#e3e0d1'
+    sights: chaotic movements, dragging feet, frustrated glaring
+    sounds: constant bickering, clumsy thuds, mismatched words
+    smells: sweaty musk, animal hides, unkempt hair
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unlikely Protector of ...
+      instructions: ''
+      table:
+        - - Three old witches, who use it as a bodyguard.
+          - Ragtag group of orphans that saved it.
+          - Goblins, because they worship it as a god.
+          - Hamlet of farmers, who feed it.
+          - Wandering circus, using it as a bouncer.
+          - Hermit, friends with both heads.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Runejaw
+    type: challenge
+    _id: f20aa0akSO6OlPWG
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Cryptic, curious
+        - Seeks to prophesize
+        - Reacts to symbolism
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!KkFsnYfldYWfUGwp.f20aa0akSO6OlPWG'
+  - name: Goldmaw
+    type: challenge
+    _id: pq61xMmWuTGft4b3
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Sharp, Greedy
+        - Seeks material gain
+        - Reacts to rare goods
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!KkFsnYfldYWfUGwp.pq61xMmWuTGft4b3'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368403818
+  modifiedTime: 1750368403818
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: KkFsnYfldYWfUGwp
+sort: 0
+_key: '!actors!KkFsnYfldYWfUGwp'
+

--- a/src/packs/monsters/Ettin__Stonevoice___Gorebark_RbLrU3pyhaGI2DdK.yml
+++ b/src/packs/monsters/Ettin__Stonevoice___Gorebark_RbLrU3pyhaGI2DdK.yml
@@ -1,0 +1,227 @@
+folder: null
+name: Ettin, Stonevoice & Gorebark
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering, two-headed figure with mismatched weapons. They lumber through
+    the wilderness, both heads bickering endlessly about trivial matters.</p>
+  notes: >-
+    <p>To pass an ettin without a fight, you'll need to persuade both heads.
+    Remember, they're dim and don't get along</p>
+  role: brute
+  tier: tough
+  traits:
+    - Constantly Bickering
+    - Clumsy Stride
+    - Speech
+  moves:
+    - Swing Weapons
+    - Headbutts
+    - Dual Shouting
+  desires:
+    - value: simple pleasures both heads can agree on.
+      are: false
+    - value: to do anything that requires precision.
+      are: false
+  sensories:
+    colors:
+      - name: Fleshy Gray
+        color: '#a9a9a9'
+      - name: Dark Leather
+        color: '#4b3621'
+      - name: Ashen White
+        color: '#e3e0d1'
+    sights: chaotic movements, dragging feet, frustrated glaring
+    sounds: constant bickering, clumsy thuds, mismatched words
+    smells: sweaty musk, animal hides, unkempt hair
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unlikely Protector of ...
+      instructions: ''
+      table:
+        - - Three old witches, who use it as a bodyguard.
+          - Ragtag group of orphans that saved it.
+          - Goblins, because they worship it as a god.
+          - Hamlet of farmers, who feed it.
+          - Wandering circus, using it as a bouncer.
+          - Hermit, friends with both heads.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Stonevoice
+    type: challenge
+    _id: kROMYVpRVv7sMdnz
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Calm, rational
+        - Seeks a good chat
+        - Reacts to wordplay
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!RbLrU3pyhaGI2DdK.kROMYVpRVv7sMdnz'
+  - name: Gorebark
+    type: challenge
+    _id: VC2KWPJEzVKd7mq4
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Aggressive, loud
+        - Seeks violence
+        - Reacts to weakness
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!RbLrU3pyhaGI2DdK.VC2KWPJEzVKd7mq4'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368404830
+  modifiedTime: 1750368404830
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: RbLrU3pyhaGI2DdK
+sort: 0
+_key: '!actors!RbLrU3pyhaGI2DdK'
+

--- a/src/packs/monsters/Ettin_uvnZ6RIGgjm0pU15.yml
+++ b/src/packs/monsters/Ettin_uvnZ6RIGgjm0pU15.yml
@@ -1,0 +1,377 @@
+folder: null
+name: Ettin
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering, two-headed figure with mismatched weapons. They lumber through
+    the wilderness, both heads bickering endlessly about trivial matters.</p>
+  notes: <p></p>
+  role: brute
+  tier: tough
+  traits:
+    - Constantly Bickering
+    - Clumsy Stride
+    - Speech
+  moves:
+    - Swing Weapons
+    - Headbutts
+    - Dual Shouting
+  desires:
+    - value: simple pleasures both heads can agree on.
+      are: false
+    - value: to do anything that requires precision.
+      are: false
+  sensories:
+    colors:
+      - name: Fleshy Gray
+        color: '#a9a9a9'
+      - name: Dark Leather
+        color: '#4b3621'
+      - name: Ashen White
+        color: '#e3e0d1'
+    sights: chaotic movements, dragging feet, frustrated glaring
+    sounds: constant bickering, clumsy thuds, mismatched words
+    smells: sweaty musk, animal hides, unkempt hair
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unlikely Protector of ...
+      instructions: ''
+      table:
+        - - Three old witches, who use it as a bodyguard.
+          - Ragtag group of orphans that saved it.
+          - Goblins, because they worship it as a god.
+          - Hamlet of farmers, who feed it.
+          - Wandering circus, using it as a bouncer.
+          - Hermit, friends with both heads.
+prototypeToken:
+  name: Dragon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Stonevoice
+    type: challenge
+    _id: kROMYVpRVv7sMdnz
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Calm, rational
+        - Seeks a good chat
+        - Reacts to wordplay
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!uvnZ6RIGgjm0pU15.kROMYVpRVv7sMdnz'
+  - name: Gorebark
+    type: challenge
+    _id: VC2KWPJEzVKd7mq4
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Aggressive, loud
+        - Seeks violence
+        - Reacts to weakness
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!uvnZ6RIGgjm0pU15.VC2KWPJEzVKd7mq4'
+  - name: Runejaw
+    type: challenge
+    _id: f20aa0akSO6OlPWG
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Cryptic, curious
+        - Seeks to prophesize
+        - Reacts to symbolism
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!uvnZ6RIGgjm0pU15.f20aa0akSO6OlPWG'
+  - name: Goldmaw
+    type: challenge
+    _id: pq61xMmWuTGft4b3
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Sharp, Greedy
+        - Seeks material gain
+        - Reacts to rare goods
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!uvnZ6RIGgjm0pU15.pq61xMmWuTGft4b3'
+  - name: Hootfang
+    type: challenge
+    _id: 3ncdhDHn8vOXzz8q
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Flamboyant, selfish
+        - Seeks real praise
+        - Reacts to boredom
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!uvnZ6RIGgjm0pU15.3ncdhDHn8vOXzz8q'
+  - name: Foulhorn
+    type: challenge
+    _id: Psb1XoGMJuezQf8v
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - false
+          - false
+      traits:
+        - Quiet, manipulative
+        - Seeks to swindle
+        - Reacts to confusion
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!uvnZ6RIGgjm0pU15.Psb1XoGMJuezQf8v'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368401928
+  modifiedTime: 1750368401928
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: uvnZ6RIGgjm0pU15
+sort: 0
+_key: '!actors!uvnZ6RIGgjm0pU15'
+

--- a/src/packs/monsters/Fey__Dryad_bezGzV1XuGUZ3Ptx.yml
+++ b/src/packs/monsters/Fey__Dryad_bezGzV1XuGUZ3Ptx.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Fey, Dryad
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Mystical tree spirits that embody the essence of a specific tree,
+    guarding it and the surrounding grove. They are fiercely protective of their
+    home.</p>
+  notes: ''
+  role: protector
+  tier: tough
+  traits:
+    - Melds With Trees
+    - One With Nature
+    - Speech
+  moves:
+    - Entangling Roots
+    - Charm Person
+    - Blossoming Burst
+  desires:
+    - value: to welcome those with good intentions.
+      are: false
+    - value: any form of unnatural change.
+      are: false
+  sensories:
+    colors:
+      - name: Mossy Green
+        color: '#566b30'
+      - name: Bark Brown
+        color: '#8b4512'
+      - name: Forest Green
+        color: '#495d3a'
+    sights: twisting vines, blooming flowers, swirling leaves
+    sounds: soft rustling, melodic birdsong, crackle of twigs
+    smells: earthy scent, woody aroma, crisp fresh leaves
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Aboreal Lineage
+      instructions: ''
+      table:
+        - - Weeping willow, shy but playful.
+          - Oak, stern and steadfast.
+          - Maple, sweet and protective.
+          - Ash, resilient and wise.
+          - Elm, mournful but warm-hearted.
+          - Yew, resilient and vengeful.
+prototypeToken:
+  name: Fey, Dryad
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368405666
+  modifiedTime: 1750368405666
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: bezGzV1XuGUZ3Ptx
+sort: 0
+_key: '!actors!bezGzV1XuGUZ3Ptx'
+

--- a/src/packs/monsters/Fey__Faery_4Px4ZxcnlB79MZKd.yml
+++ b/src/packs/monsters/Fey__Faery_4Px4ZxcnlB79MZKd.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Fey, Faery
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Tiny, winged creatures with a mischevious nature. They flit through
+    meadows, casting illusions and playing tricks on wanderers for their own
+    amusement.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Swarm Together
+    - Invisibility-At-Will
+    - Speech
+  moves:
+    - Fairy Dust
+    - Dazzling Lights
+    - Minor Illusions
+  desires:
+    - value: to play mostly harmless tricks on mortals.
+      are: false
+    - value: to be anywhere near iron.
+      are: false
+  sensories:
+    colors:
+      - name: Petal Pink
+        color: '#d2a5a0'
+      - name: Soft Lavender
+        color: '#9470dc'
+      - name: Pale Blue
+        color: '#a9c4d5'
+    sights: glittering trails, darting figures, fleeting glimpses
+    sounds: airy giggling, fluttering of tiny wings, melodic chimes
+    smells: delicate nectar, lavender and jasmine, sugary aroma
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Fairy Circles
+      instructions: ''
+      table:
+        - - Mushrooms glowing faintly in the dusk.
+          - Ring of sunflowers in a grassy field.
+          - Fallen leaves after a rain.
+          - Precarious pebble towers, defying gravity.
+          - Dancing fireflies in a glowing spiral.
+          - Ring of acorns around a sapling.
+prototypeToken:
+  name: Fey, Faery
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368406800
+  modifiedTime: 1750368406800
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 4Px4ZxcnlB79MZKd
+sort: 0
+_key: '!actors!4Px4ZxcnlB79MZKd'
+

--- a/src/packs/monsters/Fey__Redcap_QZrneSVrUxsEJ1T1.yml
+++ b/src/packs/monsters/Fey__Redcap_QZrneSVrUxsEJ1T1.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Fey, Redcap
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Malicious, bloodthirsty creatures with a blood-red cap, driven by
+    violence and a love for carnage. They often manifest near murder sites.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Bloodlust
+    - Grim Cackling
+    - Speech
+  moves:
+    - Scythe Slash
+    - Blood Frenzy
+    - Make Skin Crawl
+  desires:
+    - value: its hat to never fully dry.
+      are: false
+    - value: to be shown its own weaknesses.
+      are: false
+  sensories:
+    colors:
+      - name: Blood Red
+        color: '#8b0101'
+      - name: Aged Leather
+        color: '#714214'
+      - name: Thicket Green
+        color: '#566b30'
+    sights: bloodshot eyes, malevolent grin, shiny scythe
+    sounds: sharp shing of a scythe, cackling laughter
+    smells: thick coppery scent of fresh blood like a fog
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Warband Bosses
+      instructions: ''
+      table:
+        - - Goretooth, feared even by its kin.
+          - Bloodsoak, who bathes in blood.
+          - Rotfoot, who would rule the fey
+          - Nocap, the hatless one.
+          - Redeyes, born of a murder most foul.
+          - Feybane, who is called betrayer.
+prototypeToken:
+  name: Fey, Redcap
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368407684
+  modifiedTime: 1750368407684
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: QZrneSVrUxsEJ1T1
+sort: 0
+_key: '!actors!QZrneSVrUxsEJ1T1'
+

--- a/src/packs/monsters/Fey__Satyr_Za7ubc4NkiPIlda1.yml
+++ b/src/packs/monsters/Fey__Satyr_Za7ubc4NkiPIlda1.yml
@@ -1,0 +1,156 @@
+folder: null
+name: Fey, Satyr
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Merry, goat-legged tricksters with a love for wine, music, and revelry.
+    They invite wanderers into their revelry, at times with a sense of
+    maliciousness.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Revelrous Spirit
+    - Enchanting Tunes
+    - Speech
+  moves:
+    - Pan Pipes
+    - Headbutt
+    - Jeering Calls
+  desires:
+    - value: to loosen mortal ties.
+      are: false
+    - value: mortals to try to resist its invitations.
+      are: false
+  sensories:
+    colors:
+      - name: Earthy Brown
+        color: '#654320'
+      - name: Autumn Tawny
+        color: '#daa521'
+      - name: Grassy Green
+        color: '#6a8e22'
+    sights: travelers into the woods, playfully malicious grin
+    sounds: hypnotic melody of panpipes, dancing and revelry
+    smells: rich scent of wine, wild berries, lingering sweetness
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Contests & Rewards
+      instructions: ''
+      table:
+        - - singing
+          - dance-off
+          - eating pies
+          - duel of wits
+          - tug-of-war
+          - archery
+        - - rare liquor
+          - gold key to nothing
+          - deed to an inn
+          - curse to give someone
+          - black eye
+          - half a treasure map
+prototypeToken:
+  name: Fey, Satyr
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368408703
+  modifiedTime: 1750368408703
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: Za7ubc4NkiPIlda1
+sort: 0
+_key: '!actors!Za7ubc4NkiPIlda1'
+

--- a/src/packs/monsters/Gargoyle_ItaMoCnoZRUy4hvP.yml
+++ b/src/packs/monsters/Gargoyle_ItaMoCnoZRUy4hvP.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Gargoyle
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Winged stone-like creatures that masquerade as part of buildings, serving
+    as guardians. They can remain motionless for years until intruders
+    approach.</p>
+  notes: ''
+  role: protector
+  tier: tough
+  traits:
+    - Stone Camouflage
+    - Eternal Vigilance
+    - Speech
+  moves:
+    - Jump Scare
+    - Snatch and Fly
+    - Stone Talons
+  desires:
+    - value: to let intruders go past the point of no return.
+      are: false
+    - value: to outlive its duty.
+      are: false
+  sensories:
+    colors:
+      - name: Stone Gray
+        color: '#696969'
+      - name: Ash Black
+        color: '#2f2f2f'
+      - name: Mossy Green
+        color: '#6a8e22'
+    sights: nothing of interest, wings unfurling, eyes opening
+    sounds: slow scrape of stone, soft whoosh of wings, heavy thud
+    smells: dusty earth, ancient stone, tang of rainwater
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Odd Wards
+      instructions: ''
+      table:
+        - - Door that must remain opened.
+          - Throne meant for a fallen king.
+          - Gate that seemingly leads nowhere.
+          - Altar long without its god.
+          - Bell tower, never once chimed.
+          - Empty stepwell, its community now dust.
+prototypeToken:
+  name: Gargoyle
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368409704
+  modifiedTime: 1750368409704
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: ItaMoCnoZRUy4hvP
+sort: 0
+_key: '!actors!ItaMoCnoZRUy4hvP'
+

--- a/src/packs/monsters/Gelatinous_Cube_tk4lOgSGW3HkjzR0.yml
+++ b/src/packs/monsters/Gelatinous_Cube_tk4lOgSGW3HkjzR0.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Gelatinous Cube
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Transparent, jelly-like masses big enough to fill the dungeon halls they
+    slide through. They engulf anything they touch and dissolve it with acidic
+    digestion.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Nearly Invisible
+    - Very Slow
+  moves:
+    - Absorb Prey
+    - Corrosive Splash
+    - Quick Dissolve
+  desires:
+    - value: to keep moving forward.
+      are: false
+    - value: tenacious objects lingering inside it.
+      are: false
+  sensories:
+    colors:
+      - name: Acidic Green
+        color: '#9acd32'
+      - name: Translucent Blue
+        color: '#87ceea'
+      - name: Pale Lime
+        color: '#d3d39f'
+    sights: faint shimmer, half-dissolved items suspended in air
+    sounds: wet sloshing, soft acidic hiss, unsettling gurgling
+    smells: sour odor of acid, stinging scent of corroded metal
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Aberrations
+      instructions: ''
+      table:
+        - - Hollow center filled with flaming, sloshing gel.
+          - Charged with crackling electric arcs.
+          - Constantly shifting in prismatic colors.
+          - Packed with razor-sharp hunks of metal.
+          - Swarm of dice-sized cubes.
+          - Impossibly dense, slow, and indestructible.
+prototypeToken:
+  name: Gelatinous Cube
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368410662
+  modifiedTime: 1750368410662
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: tk4lOgSGW3HkjzR0
+sort: 0
+_key: '!actors!tk4lOgSGW3HkjzR0'
+

--- a/src/packs/monsters/Genie_U8cbakUrDWJHgjI4.yml
+++ b/src/packs/monsters/Genie_U8cbakUrDWJHgjI4.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Genie
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Powerful elemental spirits that command the forces of nature. They grant
+    wishes, but often twist them to serve mysterious and unpredictable ends.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Elemental Mastery
+    - Regal Confidence
+    - Speech
+  moves:
+    - Twisted Wish
+    - Command Element
+    - Whirlwind
+  desires:
+    - value: its wishes to teach mortals a lesson.
+      are: false
+    - value: to be bound or controlled.
+      are: false
+  sensories:
+    colors:
+      - name: Burnished Gold
+        color: '#b8860b'
+      - name: Sapphire Blue
+        color: '#5989c9'
+      - name: Mystic Purple
+        color: '#6e498c'
+    sights: flowing robes, runes and symbols etched in the air
+    sounds: ethereal hum, whoosh of wind, crackle of magic
+    smells: crisp air, lingering jasmine and lotus, alluring spice
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Genie Twists
+      instructions: ''
+      table:
+        - - Tries to destroy itself with the wish.
+          - Tries too hard to improve the wish.
+          - Makes the wish somehow achieve the opposite.
+          - Mishears, changing one letter in the wish.
+          - Splits the wish around unevenly.
+          - Can't actually grant wishes, but will not admit it.
+prototypeToken:
+  name: Genie
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368412506
+  modifiedTime: 1750368412506
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: U8cbakUrDWJHgjI4
+sort: 0
+_key: '!actors!U8cbakUrDWJHgjI4'
+

--- a/src/packs/monsters/Giant__Fire_TDEyq8AwUJcvemH4.yml
+++ b/src/packs/monsters/Giant__Fire_TDEyq8AwUJcvemH4.yml
@@ -1,0 +1,272 @@
+folder: null
+name: Giant, Fire
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Ironclad tyrants of flame and forge, valuing order and dominance above
+    all. They shape kingdoms through fire, steel, and unyielding will.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Magma-blooded
+    - Blazing Aura
+  moves:
+    - Flaming Hammer
+    - Hurl Magma
+    - Blaze Wave
+  desires:
+    - value: to haul plunder back to its volcanic fortress.
+      are: false
+    - value: to cross bodies of water.
+      are: false
+  sensories:
+    colors:
+      - name: Burnt Ember
+        color: '#cc5600'
+      - name: Fiery Red
+        color: '#b22222'
+      - name: Coal Black
+        color: '#2f2f2f'
+    sights: huge swathes of scorched earth, trails of magma
+    sounds: roaring crackle, whoosh of fire, rumble of lava
+    smells: stifling smoky odor, charred earth, scorched stone
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Seat of Power
+      instructions: ''
+      table:
+        - - charred stone bastion
+          - grand obsidian spire
+          - ash-choked estate
+          - steamy sulfur baths
+          - basalt cathedral
+          - clanging forgeworks
+        - - island in a lava river
+          - sheer volcanic cliffside
+          - billowing caldera rim
+          - center of a vast plain
+          - beneath magma-falls
+          - sulfuric cave system
+prototypeToken:
+  name: Giant, Fire
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Head & Magic
+    type: challenge
+    _id: TfMRnVnLGB7TQLbz
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Collapse Tunnels
+        - Offer Alliance
+        - Summon Devils
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!TDEyq8AwUJcvemH4.TfMRnVnLGB7TQLbz'
+  - name: Body & Prowess
+    type: challenge
+    _id: SmkG4QYm7RMBJHav
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Thick armor
+        - Fiery spear
+      moves:
+        - Spear Sweep
+        - Foot Stomp
+        - Grab & Throw
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!TDEyq8AwUJcvemH4.SmkG4QYm7RMBJHav'
+  - name: Volcanic Lair
+    type: challenge
+    _id: SCo7ACb654OJplpZ
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Lava pits, choking sulfuric clouds
+        - 6d Spew Magma
+      moves:
+        - 6d Firelings (Mook Blasters)
+        - 3 Hellhounds (Tough Brutes)
+        - 4d | Fire Elemental (Elite Blaster)
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!TDEyq8AwUJcvemH4.SCo7ACb654OJplpZ'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368415844
+  modifiedTime: 1750368415844
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: TDEyq8AwUJcvemH4
+sort: 0
+_key: '!actors!TDEyq8AwUJcvemH4'
+

--- a/src/packs/monsters/Giant__Frost_BtbyjzUztKLvhRPE.yml
+++ b/src/packs/monsters/Giant__Frost_BtbyjzUztKLvhRPE.yml
@@ -1,0 +1,267 @@
+folder: null
+name: Giant, Frost
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Brutal lords of ice and stone, honoring strength and tradition above all.
+    They seek to prove themselves worthy of the harsh, unforgiving frozen
+    wastes.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Icy Footsteps
+    - Slowness Aura
+    - Speech
+  moves:
+    - Frost Breath
+    - Summon Blizzard
+    - Frozen Hammer
+  desires:
+    - value: to rule the sweeping vistas of the tundra.
+      are: false
+    - value: to feel the cold seep from its bones.
+      are: false
+  sensories:
+    colors:
+      - name: Icy Blue
+        color: '#add9e6'
+      - name: Frosty Gray
+        color: '#d3d3d3'
+      - name: Stone Gray
+        color: '#696969'
+    sights: massive hanging icicles, clouds of snowflakes
+    sounds: crack of freezing, howling icy winds, crunch of frost
+    smells: biting cold, frigid air, pine trees, fresh snow
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unexpected Locations
+      instructions: ''
+      table:
+        - - Entire tower built around it, keeping it frozen.
+          - Steps through a portal and onto a sandy beach.
+          - Riding on a floating iceberg towards a port city.
+          - In a grand wizard's laboratory.
+          - Emerging from a bizarre mid-spring blizzard.
+          - Tied down in the middle of a vast desert.
+prototypeToken:
+  name: Giant, Frost
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Outer Courtyard
+    type: challenge
+    _id: DPY1AOkPcTgPa0oF
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Cracked ice pillars and statues
+      moves:
+        - 4d Iceling Cloud (Mook Swarmer)
+        - 8d | Remorhaz (Elite Predator)
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!BtbyjzUztKLvhRPE.DPY1AOkPcTgPa0oF'
+  - name: Icy Halls
+    type: challenge
+    _id: xz6BeTgNv83MTfgC
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Labyrinthine halls
+        - 4d Terrifying howling
+      moves:
+        - 6d Winter Wolves (Tough Predators)
+        - 6d | Dire Winter Wolf (Elite Overseer)
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!BtbyjzUztKLvhRPE.xz6BeTgNv83MTfgC'
+  - name: Frozen Throneroom
+    type: challenge
+    _id: jjgDIDaDecJ5e7j8
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Intensely cold
+        - 4d Falling Icicles
+      moves:
+        - 3 Ice Trolls (Tough Marauders)
+        - 6d Air Elementals (Elite Blasters)
+        - 8d-8d | Frost Giant (Boss Blaster)
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!BtbyjzUztKLvhRPE.jjgDIDaDecJ5e7j8'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368416685
+  modifiedTime: 1750368416685
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: BtbyjzUztKLvhRPE
+sort: 0
+_key: '!actors!BtbyjzUztKLvhRPE'
+

--- a/src/packs/monsters/Giant__Hill_x38xtlisaYWCOyLC.yml
+++ b/src/packs/monsters/Giant__Hill_x38xtlisaYWCOyLC.yml
@@ -1,0 +1,276 @@
+folder: null
+name: Giant, Hill
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, dim-witted gluttons with big bellies and bulging muscles. They
+    crush and consume all in their path, living only for the next feast.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Bottomless Appetite
+    - Too Dumb to Trick
+    - Speech (limited)
+  moves:
+    - Smash It
+    - Throw it
+    - Eat It
+  desires:
+    - value: to force weaker creatures to bring it food.
+      are: false
+    - value: to be confronted with logic and reason.
+      are: false
+  sensories:
+    colors:
+      - name: Dusty Tan
+        color: '#d1b48c'
+      - name: Earthy Brown
+        color: '#8b4512'
+      - name: Muddy Green
+        color: '#566b30'
+    sights: bulging muscles, bloated belly, ragged clothes
+    sounds: guttural burps, dumb chuckles, heavy breathing
+    smells: overpowering stench of sweat, sour rotting food
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Quirks
+      instructions: ''
+      table:
+        - - Always brewing up a brand new stew.
+          - Hoards small, shiny objects—like mirrors.
+          - Roams with a large pack of stray dogs.
+          - Exceptionally rotund, even for a hill giant.
+          - Extremely short, for a hill giant.
+          - Thinks even the slightest odd thing is hilarious.
+prototypeToken:
+  name: Giant, Hill
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: The Basic Concept
+    type: challenge
+    _id: Q21gZZkV0BDbfFo8
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Hates big words
+      moves:
+        - Scratches Head
+        - Repeats Wrongly
+        - Loses Track
+      failure:
+        - pool:
+            diceNum: 4
+            max: null
+          value: ✘ Gets Cranky
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!x38xtlisaYWCOyLC.Q21gZZkV0BDbfFo8'
+  - name: What It Wants
+    type: challenge
+    _id: jB9gOyHYcr8CxUdB
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Wants Too Much
+        - Belly Rumbles
+        - Wants Proof
+      failure:
+        - pool:
+            diceNum: 0
+            max: null
+          value: ✘ Mention Food
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!x38xtlisaYWCOyLC.jB9gOyHYcr8CxUdB'
+  - name: Sealing the Deal
+    type: challenge
+    _id: uJgNgqRsTCwu2kka
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 6
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Sudden "Good" Idea
+        - Changes The Deal
+        - Repeats The Obvious
+      failure:
+        - pool:
+            diceNum: 0
+            max: null
+          value: ✘ Fickle (rolling a grim)
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!x38xtlisaYWCOyLC.uJgNgqRsTCwu2kka'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368417676
+  modifiedTime: 1750368417676
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: x38xtlisaYWCOyLC
+sort: 0
+_key: '!actors!x38xtlisaYWCOyLC'
+

--- a/src/packs/monsters/Giant__Storm_IvOdNeSjrmmqV8ZT.yml
+++ b/src/packs/monsters/Giant__Storm_IvOdNeSjrmmqV8ZT.yml
@@ -1,0 +1,303 @@
+folder: null
+name: Giant, Storm
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Regal rulers of sea and sky, embodying wisdom and natural order. They
+    summon storms to enforce balance, driven to maintain the world's harmony</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Crackling Aura
+    - Commanding Presence
+    - Speech
+  moves:
+    - Thunderbolt
+    - Thunderclap
+    - Summon Storm
+  desires:
+    - value: to enforce what it sees as the natural order.
+      are: false
+    - value: to see established order devolve into chaos.
+      are: false
+  sensories:
+    colors:
+      - name: Electric Blue
+        color: '#4682b4'
+      - name: Cloudy Sky
+        color: '#b0c4dd'
+      - name: Stormy Gray
+        color: '#778898'
+    sights: crackling arcs of lightning, regal figure on the horizon
+    sounds: deafening boom, wind rushing, building static hum
+    smells: electrified air, rain-soaked earth, wet stone
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Arrives Alongside ...
+      instructions: ''
+      table:
+        - - Hurricane, sweeping away defiance.
+          - Twin tornados, ripping apart the unrepentant.
+          - Hailstorm, battering the guilty into confession.
+          - Lightning storm, searing away deceit.
+          - Torrential downpour, washing away corruption.
+          - Waterspouts, dragging wrongdoers to judgment.
+prototypeToken:
+  name: Giant, Storm
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Twin Tornado A
+    type: challenge
+    _id: RPnwAXHX6dRlhmRy
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Rip Through Town
+        - Debris Barrage
+      failure: []
+    effects: []
+    folder: null
+    sort: 100000
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!IvOdNeSjrmmqV8ZT.RPnwAXHX6dRlhmRy'
+  - name: Head & Magic
+    type: challenge
+    _id: 1qIwXF8G9jbHBole
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Arcane Static
+        - Summon Elementals
+        - Sheet Lightning
+      failure: []
+    effects: []
+    folder: null
+    sort: 200000
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!IvOdNeSjrmmqV8ZT.1qIwXF8G9jbHBole'
+  - name: Body & Prowess
+    type: challenge
+    _id: nu4ekHaxUcgwIoiB
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Kick Over Wall
+        - Throw Castle Turret
+        - Shake Off Climbers
+      failure:
+        - pool:
+            diceNum: 0
+            max: null
+          value: ✘ The king dies
+    effects: []
+    folder: null
+    sort: 400000
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!IvOdNeSjrmmqV8ZT.nu4ekHaxUcgwIoiB'
+  - name: Twin Tornado B
+    type: challenge
+    _id: HdIzBUhzJbKxLPep
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits: []
+      moves:
+        - Rip Through Town
+        - Debris Barrage
+      failure: []
+    effects: []
+    folder: null
+    sort: 150000
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!IvOdNeSjrmmqV8ZT.HdIzBUhzJbKxLPep'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368418511
+  modifiedTime: 1750368418511
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: IvOdNeSjrmmqV8ZT
+sort: 0
+_key: '!actors!IvOdNeSjrmmqV8ZT'
+

--- a/src/packs/monsters/Gibbering_Mouther_PHBht1yKmIrXhmrk.yml
+++ b/src/packs/monsters/Gibbering_Mouther_PHBht1yKmIrXhmrk.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Gibbering Mouther
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Writhing masses of eyes and mouths, constantly babbling incoherently.
+    They confuse and madden foes with the chaotic sounds and frenzied
+    mayhem.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Maddening Babble
+    - Chaotic Form
+  moves:
+    - Blinding Spittle
+    - Mind Haze
+    - Swallow Whole
+  desires:
+    - value: to add more eyes and mouths to itself.
+      are: false
+    - value: for its gibberish to be understood.
+      are: false
+  sensories:
+    colors:
+      - name: Pale Flesh
+        color: '#fee4c3'
+      - name: Meaty Red
+        color: '#8b0101'
+      - name: Fleshy Pink
+        color: '#c18680'
+    sights: droplets of saliva, bits of meat, bubbling flesh
+    sounds: slurping, high-pitched screeches, moans, laughter
+    smells: sour odor of bile and rot, viscera, rancid meat
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Voices in the Chaos
+      instructions: ''
+      table:
+        - - Familiar voices calling your name.
+          - Fragments of broken promises.
+          - Pleas for help and forgiveness.
+          - Mocking tones from an old enemy.
+          - Chants from forgotten rituals.
+          - Your own voice, screaming your thoughts.
+prototypeToken:
+  name: Gibbering Mouther
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368419429
+  modifiedTime: 1750368419429
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: PHBht1yKmIrXhmrk
+sort: 0
+_key: '!actors!PHBht1yKmIrXhmrk'
+

--- a/src/packs/monsters/Golem_mX7ZCTbIAhJNd1st.yml
+++ b/src/packs/monsters/Golem_mX7ZCTbIAhJNd1st.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Golem
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Magically animated constructs forged from various materials. They fulfill
+    their creator's commands with unwavering obedience.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Unyielding
+    - Immune To Magic
+  moves:
+    - Smashing Fists
+    - Booming Stomps
+    - Mindless Charge
+  desires:
+    - value: to obey its creator's commands to the exact letter.
+      are: false
+    - value: to be uncertain of what to do.
+      are: false
+  sensories:
+    colors:
+      - name: Clay Brown
+        color: '#8b4512'
+      - name: Iron Rust
+        color: '#801817'
+      - name: Stone gray
+        color: '#696969'
+    sights: lumbering form, carved runes, glowing cracks
+    sounds: grinding joints, hollow thuds, faint buzz of magic
+    smells: overwhelming scent of the material it was made of
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Golem Construction
+      instructions: ''
+      table:
+        - - Clay, with a malleable form.
+          - Iron, with a strong magnetic pull.
+          - Crystal, refracting light into dazzling shards.
+          - Jade, with a mind and will of its own.
+          - Flesh, forming tiny flesh or blood golems if cut.
+          - Wood, regrowing damaged parts quickly.
+prototypeToken:
+  name: Golem
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368420196
+  modifiedTime: 1750368420196
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: mX7ZCTbIAhJNd1st
+sort: 0
+_key: '!actors!mX7ZCTbIAhJNd1st'
+

--- a/src/packs/monsters/Gorgon_tFYUAwkOxXlWd6XP.yml
+++ b/src/packs/monsters/Gorgon_tFYUAwkOxXlWd6XP.yml
@@ -1,0 +1,147 @@
+folder: null
+name: Gorgon
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Metal-plated bulls that snort out a cloud of petrifying gas. They charge
+    through it and shatter the stone victim into a thousand pieces.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Thick Metallic Hide
+  moves:
+    - Petrifying Breath
+    - Bull Rush
+    - Horn Toss
+  desires:
+    - value: to charge anything that dares confront it.
+      are: false
+    - value: flashy distractions.
+      are: false
+  sensories:
+    colors:
+      - name: Metallic Gray
+        color: '#a9a9a9'
+      - name: Bronze Highlights
+        color: '#cd8032'
+      - name: Gaseous Green
+        color: '#a1a875'
+    sights: serpentine eyes, gas tendrils seeping from nostrils
+    sounds: sliding metal plates, mechanical snorts, hiss of steam
+    smells: heavy metallic odor, slight staleness in the air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Metallic Variations
+      instructions: ''
+      table:
+        - - Titanium, light and incredibly fast.
+          - Lead, slow but nearly indestructible.
+          - Steel, covered in sharp spikes.
+          - Silver, blindingly reflecting light.
+          - Brass, emitting an unsettling hum.
+          - Bronze, resisting all magic.
+prototypeToken:
+  name: Gorgon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368420981
+  modifiedTime: 1750368420981
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: tFYUAwkOxXlWd6XP
+sort: 0
+_key: '!actors!tFYUAwkOxXlWd6XP'
+

--- a/src/packs/monsters/Grick_th6MCwIhPI9F3jye.yml
+++ b/src/packs/monsters/Grick_th6MCwIhPI9F3jye.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Grick
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Slithering, worm-like creatures with hooked tentacles and a beak. They
+    hide in dark caverns, taking great care to ambush prey with precise
+    strikes.</p>
+  notes: ''
+  role: lurker
+  tier: tough
+  traits:
+    - Rocky Camouflage
+    - Extended Reach
+  moves:
+    - Tentacle Swipe
+    - Beak Snap
+    - Hasty Retreat
+  desires:
+    - value: to leave no trace of its hunt.
+      are: false
+    - value: to miss a chance at a meal.
+      are: false
+  sensories:
+    colors:
+      - name: Slate Gray
+        color: '#708090'
+      - name: Mauve Gray
+        color: '#b783a7'
+      - name: Dark Olive
+        color: '#566b30'
+    sights: squirming tentacles, intense gaze, faint movement
+    sounds: soft slithering, faint clicking, sudden snapping
+    smells: musty earth, damp rock, faintly fishy scent
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Side Effects of Magical Experimentation
+      instructions: ''
+      table:
+        - - Cloaks the whole area in darkness.
+          - Bursts into blinding light when it strikes.
+          - Releases a cloud of sleep gas when struck.
+          - Lets out shrill, echoing whistles.
+          - Absorbs all sound into utter silence.
+          - Tentacles stretch three times normal length.
+prototypeToken:
+  name: Grick
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368422042
+  modifiedTime: 1750368422042
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: th6MCwIhPI9F3jye
+sort: 0
+_key: '!actors!th6MCwIhPI9F3jye'
+

--- a/src/packs/monsters/Griffon_brL1hqwNm5EJSfA9.yml
+++ b/src/packs/monsters/Griffon_brL1hqwNm5EJSfA9.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Griffon
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Majestic creatures with the body of a lion and the wings of an eagle.
+    They're fierce predators and highly territorial, often nesting on high
+    mountain peaks.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Keen Watch
+    - Wild Majesty
+  moves:
+    - Warning Woosh
+    - Beak Snap
+    - Resonant Screech
+  desires:
+    - value: for its screeches to warn intruders away.
+      are: false
+    - value: any threat at all to its kin.
+      are: false
+  sensories:
+    colors:
+      - name: Lion Gold
+        color: '#b8860b'
+      - name: Feathery White
+        color: '#d3d3d3'
+      - name: Stormy Blue
+        color: '#6a7b8b'
+    sights: majestic soaring, flash of golden fur, knowing eyes
+    sounds: beak snap, flutter of feathers, scratching the ground
+    smells: crisp mountain air, faint scent of wild prey
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: People It Terrorizes
+      instructions: ''
+      table:
+        - - Satyrs, drawn by their celebrations.
+          - Hags, which it hunts for sport.
+          - Shepherds, raiding their flocks.
+          - Merchant caravans, curious about their carts.
+          - Hunters, in revenge for killing kin.
+          - Bandits, scaring them out of its lands.
+prototypeToken:
+  name: Griffon
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368424280
+  modifiedTime: 1750368424280
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: brL1hqwNm5EJSfA9
+sort: 0
+_key: '!actors!brL1hqwNm5EJSfA9'
+

--- a/src/packs/monsters/Hag__Night_UYZlzREhgjmtp6fl.yml
+++ b/src/packs/monsters/Hag__Night_UYZlzREhgjmtp6fl.yml
@@ -1,0 +1,155 @@
+folder: null
+name: Hag, Night
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Sinister figures that embody nightmares, manipulating dreams to terrorize
+    mortals. They're devious and deal in dark bargains.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Was in Your Dreams
+    - Shadowy Teleport
+    - Speech
+  moves:
+    - Nightmares
+    - Phantasmal Form
+    - Eerie Whisper
+  desires:
+    - value: to explore the true depths of your fears.
+      are: false
+    - value: to have its own fears exposed.
+      are: false
+  sensories:
+    colors:
+      - name: Midnight Blue
+        color: '#3b4d71'
+      - name: Shadow Black
+        color: '#2f2f2f'
+      - name: Deep Purple
+        color: '#4b0081'
+    sights: shrouded in shadows, trail of purple mist
+    sounds: eerie whispers, fluttering cloak, creak of unseen steps
+    smells: cool night air, hint of aged leather
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Night Spell Crucible
+      instructions: Make 3 spells (roll 2d6 three times)
+      table:
+        - - shrouded
+          - shivering
+          - whispering
+          - muted
+          - bleak
+          - eerie
+        - - gloom
+          - touch
+          - glimmer
+          - aura
+          - breath
+          - moan
+prototypeToken:
+  name: Hag, Night
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368425043
+  modifiedTime: 1750368425043
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: UYZlzREhgjmtp6fl
+sort: 0
+_key: '!actors!UYZlzREhgjmtp6fl'
+

--- a/src/packs/monsters/Hag__Sea_QssIJgb0Ac26wpKX.yml
+++ b/src/packs/monsters/Hag__Sea_QssIJgb0Ac26wpKX.yml
@@ -1,0 +1,156 @@
+folder: null
+name: Hag, Sea
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Grotesque sea-dwellers whose gaze inspires terror. They lurk in coastal
+    caves, cursing sailors and reveling in the fearful cries of the
+    drowning.</p>
+  notes: ''
+  role: tactician
+  tier: tough
+  traits:
+    - Knows Your Sins
+    - Watery Teleport
+    - Speech
+  moves:
+    - Hideous Gaze
+    - Drowning Curse
+    - Call Creatures
+  desires:
+    - value: to collect souls lost to the depths of the seas.
+      are: false
+    - value: someone to make their fortune on the seas.
+      are: false
+  sensories:
+    colors:
+      - name: Seaweed Green
+        color: '#2e8a57'
+      - name: Dark Driftwood
+        color: '#4b3621'
+      - name: Sea Blue
+        color: '#4682b4'
+    sights: slimy skin, kelp entangled hair, glassy eyes
+    sounds: waves crashing, soft gurgles, echoing calls
+    smells: saltwater, fish rot, briny scent of seaweed
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Sea Spell Crucible (Make 3 Spells)
+      instructions: Roll 2d6 three times.
+      table:
+        - - swelling
+          - rippling
+          - gurgling
+          - foamy
+          - surging
+          - salty
+        - - shanty
+          - groan
+          - grip
+          - ebb
+          - wave
+          - current
+prototypeToken:
+  name: Hag, Sea
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368425832
+  modifiedTime: 1750368425832
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: QssIJgb0Ac26wpKX
+sort: 0
+_key: '!actors!QssIJgb0Ac26wpKX'
+

--- a/src/packs/monsters/Hag__Storm_qAl6LEZp80HrgrGF.yml
+++ b/src/packs/monsters/Hag__Storm_qAl6LEZp80HrgrGF.yml
@@ -1,0 +1,156 @@
+folder: null
+name: Hag, Storm
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fierce figures that roam coastal cliffs, summoning winds and lightning.
+    They unleash their wrath on settlements, making sure none grow too
+    comfortable.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Always Stormy
+    - Windrider
+    - Speech
+  moves:
+    - Conjure Tempests
+    - Lightning Strike
+    - Thunder Boom
+  desires:
+    - value: to wreak havoc where stability prevails.
+      are: false
+    - value: the calm center of its own fury revealed.
+      are: false
+  sensories:
+    colors:
+      - name: Electric Blue
+        color: '#6a7b8b'
+      - name: Rainy Teal
+        color: '#3b6a7a'
+      - name: Stormy Gray
+        color: '#778898'
+    sights: dark clouds swirling, crackling electricity
+    sounds: howling winds, crackle of lightning, roaring thunder
+    smells: rain-soaked air, faint scent of wet earth
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Storm Spell Crucible (Make 3 spells)
+      instructions: Roll 2d6 three times.
+      table:
+        - - tattered
+          - crackling
+          - biting
+          - howling
+          - thunderous
+          - surging
+        - - torrent
+          - clap
+          - arc
+          - boom
+          - flash
+          - chant
+prototypeToken:
+  name: Hag, Storm
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368426791
+  modifiedTime: 1750368426791
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: qAl6LEZp80HrgrGF
+sort: 0
+_key: '!actors!qAl6LEZp80HrgrGF'
+

--- a/src/packs/monsters/Hag__Swamp_Ekp0bTwzGU6HbElY.yml
+++ b/src/packs/monsters/Hag__Swamp_Ekp0bTwzGU6HbElY.yml
@@ -1,0 +1,155 @@
+folder: null
+name: Hag, Swamp
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Wicked figures lurking in fetid bogs, weaving illusions to torment
+    travelers. They spread decay and poison with sadistic glee.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Swampy Camouflage
+    - Decaying Touch
+    - Speech
+  moves:
+    - Illusions
+    - Toxic Cloud
+    - Ensnaring Vines
+  desires:
+    - value: to let the creatures of the swamp do all the work.
+      are: false
+    - value: its swamp becoming someone's shortcut.
+      are: false
+  sensories:
+    colors:
+      - name: Bog Green
+        color: '#566b30'
+      - name: Dank Moss
+        color: '#3d4f1d'
+      - name: Peat Brown
+        color: '#8b4512'
+    sights: gnarled branches, hanging moss, buzzing flies
+    sounds: creaking of trees, croak of swamp creatures, cackling
+    smells: decaying leaves, putrid water, mud
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Swamp Spell Crucible (Make 3 spells)
+      instructions: Roll 2d6 three times.
+      table:
+        - - squelching
+          - oozing
+          - reeking
+          - rotting
+          - sinking
+          - writhing
+        - - mire
+          - leech
+          - smother
+          - swallow
+          - pull
+          - cloud
+prototypeToken:
+  name: Hag, Swamp
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368427677
+  modifiedTime: 1750368427677
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: Ekp0bTwzGU6HbElY
+sort: 0
+_key: '!actors!Ekp0bTwzGU6HbElY'
+

--- a/src/packs/monsters/Hell_Hound_KyRr7kysgODpU3ZC.yml
+++ b/src/packs/monsters/Hell_Hound_KyRr7kysgODpU3ZC.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Hell Hound
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fiery, vicious hounds with glowing eyes and smelling of brimstone. They
+    hunt in packs and track down souls marked for damnation.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Pack Hunter
+    - Fiery Tracks
+    - Understands Language
+  moves:
+    - Flame Breath
+    - Howling Call
+    - Warning Growl
+  desires:
+    - value: to make the guilty pay.
+      are: false
+    - value: being forced out into the stinging rains.
+      are: false
+  sensories:
+    colors:
+      - name: Ember Red
+        color: '#b22222'
+      - name: Coal Black
+        color: '#2f2f2f'
+      - name: Charcoal Gray
+        color: '#374550'
+    sights: smoking nostrils, singed grass, bed of ashes
+    sounds: deep growls, crackling flames, claws scraping stone
+    smells: sulfur and brimstone, charred flesh
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Call to Hunt
+      instructions: ''
+      table:
+        - - Pursuing souls marked by broken oaths.
+          - Stalking souls escaped from the underworld.
+          - Hunting traitors who betrayed their own kin.
+          - Tracking those who spilt innocent blood.
+          - Hounding those who flee from justice.
+          - Wrongly on the trail of the completely innocent.
+prototypeToken:
+  name: Hell Hound
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368428521
+  modifiedTime: 1750368428521
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: KyRr7kysgODpU3ZC
+sort: 0
+_key: '!actors!KyRr7kysgODpU3ZC'
+

--- a/src/packs/monsters/Hippogriff_qMZTvQh3iDoZC9j6.yml
+++ b/src/packs/monsters/Hippogriff_qMZTvQh3iDoZC9j6.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Hippogriff
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Noble creatures with the body of a horse and wings of an eagle. They soar
+    over plains and mountains, loyal and protective to those who earn their
+    trust.</p>
+  notes: ''
+  role: protector
+  tier: tough
+  traits:
+    - Noble Presence
+    - Elegant Speed
+  moves:
+    - Talon Strike
+    - Beak Snap
+    - Take Flight
+  desires:
+    - value: for its young to grow strong and wild.
+      are: false
+    - value: those who confront others with aggression.
+      are: false
+  sensories:
+    colors:
+      - name: Chestnut Brown
+        color: '#8b4512'
+      - name: Soft Ivory
+        color: '#f5f5db'
+      - name: Golden Tawny
+        color: '#daa521'
+    sights: majestic wings, sharp beak, talons gripping the earth
+    sounds: rush of wind, shrill cries, gallop of hooves
+    smells: earthy scent of open fields, fresh mountain air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Chosen Riders
+      instructions: ''
+      table:
+        - - Legendary thief who helped it escape.
+          - Outcast noble seeking redemption.
+          - Ranger who patrols distant borders.
+          - Wicked hag that it thinks is a hero.
+          - Normal farmer that it was raised by.
+          - Gnoll that nursed it back to health.
+prototypeToken:
+  name: Hippogriff
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368429284
+  modifiedTime: 1750368429284
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: qMZTvQh3iDoZC9j6
+sort: 0
+_key: '!actors!qMZTvQh3iDoZC9j6'
+

--- a/src/packs/monsters/Hydra_xl8beleA5EKivoRz.yml
+++ b/src/packs/monsters/Hydra_xl8beleA5EKivoRz.yml
@@ -1,0 +1,371 @@
+folder: null
+name: Hydra
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, reptilian beasts with multiple heads that can regrow when
+    severed, making them almost impossible to kill. They lurk in swamps and dark
+    waters.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Incredibly vigilant
+    - Regenerating heads
+  moves:
+    - Pulls Arms & Legs
+    - Frenzied Biting
+    - Regrow Head Now
+  desires:
+    - value: to keep threats in front of it.
+      are: false
+    - value: anything ever touching its body.
+      are: false
+  sensories:
+    colors:
+      - name: Marsh Green
+        color: '#3d4f1d'
+      - name: Dusky Blue
+        color: '#49646b'
+      - name: Rusty Red
+        color: '#8b0101'
+    sights: wide-open jaws, glistening scales
+    sounds: hissing, splash of water, snapping of giant jaws
+    smells: rotting vegetation, stagnant muck water
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unique Head Regrowths
+      instructions: ''
+      table:
+        - - Sludge head, which spews a poisonous fog.
+          - Only the skull, filled with necrotic energy.
+          - Eyeless head, which can read minds.
+          - Beautiful head with a hypnotic singsong.
+          - Horned head that can ram with force.
+          - The cut head rolls away to form a new hydra.
+prototypeToken:
+  name: Hydra
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Head
+    type: challenge
+    _id: YB7TdIqLi67LsilM
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 2
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Protects The Body
+        - 3d Regrow Head
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!xl8beleA5EKivoRz.YB7TdIqLi67LsilM'
+  - name: Head
+    type: challenge
+    _id: Rpu4nU4lzz0zfqD0
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 2
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Protects the body
+        - 3d Regrow Head
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!xl8beleA5EKivoRz.Rpu4nU4lzz0zfqD0'
+  - name: Head
+    type: challenge
+    _id: DWGwFrfNOnV0F91s
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 2
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Protects The Body
+        - 3d Regrow Head
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!xl8beleA5EKivoRz.DWGwFrfNOnV0F91s'
+  - name: Head
+    type: challenge
+    _id: jySM6exyTn8raqlz
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 2
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Protects Body
+        - 3d Regrow Head
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!xl8beleA5EKivoRz.jySM6exyTn8raqlz'
+  - name: Body
+    type: challenge
+    _id: UXHDPQo5gKKexPXR
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 8
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Mostly submerged
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!xl8beleA5EKivoRz.UXHDPQo5gKKexPXR'
+  - name: Head
+    type: challenge
+    _id: UDvjeps2uHU9vmZt
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 2
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Watches Behind
+        - Cuts Off Escapes
+        - 3d Regrow Head
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!xl8beleA5EKivoRz.UDvjeps2uHU9vmZt'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368430143
+  modifiedTime: 1750368430143
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: xl8beleA5EKivoRz
+sort: 0
+_key: '!actors!xl8beleA5EKivoRz'
+

--- a/src/packs/monsters/Lamia_RCdELwbNlzujG7rz.yml
+++ b/src/packs/monsters/Lamia_RCdELwbNlzujG7rz.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Lamia
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Decadent, lion-bodied enchantresses that lure victims with charm and
+    illusion, seeking to corrupt and control them. They're driven by hedonistic
+    desires.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Graceful Agility
+    - Illusory Person Form
+    - Speech
+  moves:
+    - Cursed Touch
+    - Illusions
+    - Enchantment
+  desires:
+    - value: to gather secrets and amusement from its victims.
+      are: false
+    - value: to think about the nature of its existence.
+      are: false
+  sensories:
+    colors:
+      - name: Dark Jade
+        color: '#264e36'
+      - name: Desert Brown
+        color: '#a0522c'
+      - name: Sandy Gold
+        color: '#d2b370'
+    sights: golden adornments, graceful silhouette, soft ripples
+    sounds: seductive laughter, sand rustling, chants on the wind
+    smells: desert breeze, faint jasmine, spicy myrrh
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: False Renown
+      instructions: ''
+      table:
+        - - Whispers that prophecies fall from their lips.
+          - Claimed to show past secrets through dreams.
+          - Rumored to bind with honeyed promises.
+          - Fabled to recall lost souls from death’s grasp.
+          - Promised to reveal one’s deepest purpose.
+          - Songs tell of dreams woven into reality.
+prototypeToken:
+  name: Lamia
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368431310
+  modifiedTime: 1750368431310
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: RCdELwbNlzujG7rz
+sort: 0
+_key: '!actors!RCdELwbNlzujG7rz'
+

--- a/src/packs/monsters/Manticore_cKHVDb13YtB3QLDz.yml
+++ b/src/packs/monsters/Manticore_cKHVDb13YtB3QLDz.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Manticore
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fierce beasts with a feline body and spiked tail. They prowl deserts and
+    plains, driving prey into flight then pelting them with volleys of deadly
+    tail spikes.</p>
+  notes: ''
+  role: marksman
+  tier: tough
+  traits:
+    - Barbed Hide
+    - Cautious
+    - Speech (Crude)
+  moves:
+    - Cruel Words
+    - Spike Volley
+    - Terrifying Roar
+  desires:
+    - value: to scare its prey into fleeing for an easy kill.
+      are: false
+    - value: to let fleeing prey get away.
+      are: false
+  sensories:
+    colors:
+      - name: Burnt Brown
+        color: '#261618'
+      - name: Desert Ochre
+        color: '#8b4512'
+      - name: Dusty Dawn
+        color: '#b19f5f'
+    sights: spikes in trees, dust clouds, long blood trails
+    sounds: guttural roars, sharp cracking of spikes landing
+    smells: dry fur, acrid dust, musky feline scent
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Symbiotic Pairings
+      instructions: ''
+      table:
+        - - Wyvern, hunts down injured prey.
+          - Hill giant, makes for a comfortable bed.
+          - Basilisk, waits to petrify escaping targets.
+          - Minotaur, lets it lair in the labyrinth.
+          - Chimera, a tense hunting pact.
+          - Underscourge, follows along from below.
+prototypeToken:
+  name: Manticore
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368434440
+  modifiedTime: 1750368434440
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: cKHVDb13YtB3QLDz
+sort: 0
+_key: '!actors!cKHVDb13YtB3QLDz'
+

--- a/src/packs/monsters/Medusa_v1m1elKj9PAhhCiw.yml
+++ b/src/packs/monsters/Medusa_v1m1elKj9PAhhCiw.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Medusa
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Cursed figures with serpentine hair and a gaze that turns onlookers into
+    stone. They hide in ancient ruins, haunted by past sorrow and
+    bitterness.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Vigilant Serpent Hair
+    - Unnatural Beauty
+    - Speech
+  moves:
+    - Petrifying Gaze
+    - Snake Hair Strike
+    - Hypnotic Charm
+  desires:
+    - value: for you to just go away.
+      are: false
+    - value: to be reminded of its past.
+      are: false
+  sensories:
+    colors:
+      - name: Viper Green
+        color: '#2e8a57'
+      - name: Bronze Gold
+        color: '#cd8032'
+      - name: Ancient Stone
+        color: '#778898'
+    sights: writhing serpent hair, statues of victims, angry eyes
+    sounds: soft hissing, vengeful muttering, sudden snap of scales
+    smells: ancient rot, moss-covered stone, stagnant air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Curse Origins
+      instructions: ''
+      table:
+        - - Vanity, punished by a mirror that never reflects.
+          - Lies, broke a promise made in desperation.
+          - Greed, forced to forever protect the relic it stole.
+          - Paranoia, having been betrayed countless times.
+          - Jealousy, spawned from unfulfilled longing.
+          - Hubris, having believed itself above the gods.
+prototypeToken:
+  name: Medusa
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368435363
+  modifiedTime: 1750368435363
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: v1m1elKj9PAhhCiw
+sort: 0
+_key: '!actors!v1m1elKj9PAhhCiw'
+

--- a/src/packs/monsters/Mimic_HkFyVHgeIgxHCTUa.yml
+++ b/src/packs/monsters/Mimic_HkFyVHgeIgxHCTUa.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Mimic
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Shapeshifting creature that disguises itself as objects to lure prey.
+    They stretch to devour victims in one gulp, springing to life when a meal is
+    assured.</p>
+  notes: ''
+  role: lurker
+  tier: tough
+  traits:
+    - Shapeshifter
+    - Adhesive Touch
+    - Understands Language
+  moves:
+    - Raise Curiosity
+    - Deflect Suspicion
+    - Swallow Whole
+  desires:
+    - value: to be carried to places with tastier meals.
+      are: false
+    - value: to turn into the same thing twice.
+      are: false
+  sensories:
+    colors:
+      - name: Corrupted Purple
+        color: '#4b0081'
+      - name: Iron Black
+        color: '#2f2f2f'
+      - name: Aged Oak
+        color: '#5d3a1a'
+    sights: shifting surfaces like melting wax, texture rippling
+    sounds: sticky slurps, sudden snaps, creaking of pressure
+    smells: sour decay of old adhesive, whiffs of trapped air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Object Forms
+      instructions: ''
+      table:
+        - - Simple, like a barrel, rug, or bookshelf.
+          - Tricky, like a door, book, or cupboard.
+          - Inviting, like a plush chair, bed, or vanity table.
+          - Horrific, like a doll, mask, or coffin.
+          - Nostalgic, like a children's toy, old hat, or lute.
+          - Necessary, like a toilet, staircase, or well.
+prototypeToken:
+  name: Mimic
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368436475
+  modifiedTime: 1750368436475
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: HkFyVHgeIgxHCTUa
+sort: 0
+_key: '!actors!HkFyVHgeIgxHCTUa'
+

--- a/src/packs/monsters/Minotaur_jv4yMVAoNboAy8nc.yml
+++ b/src/packs/monsters/Minotaur_jv4yMVAoNboAy8nc.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Minotaur
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering, bull-headed figures that guard labyrinths. They relentlessly
+    stalk its passages, charging with savage force at the first sign of
+    intruders.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Thick Hide
+    - Labyrinth Sense
+    - Speech
+  moves:
+    - Maze Ambush
+    - Bull Snorts
+    - Horn Toss
+  desires:
+    - value: victims to enter its maze, to satisfy its bloodlust.
+      are: false
+    - value: to feel the sting of solitude yet again.
+      are: false
+  sensories:
+    colors:
+      - name: Dark Leather
+        color: '#4b3621'
+      - name: Bull Brown
+        color: '#8b4512'
+      - name: Bestial Red
+        color: '#8b0101'
+    sights: bulging muscles, hooves kicking up dust
+    sounds: angry snorts, thud of cloven hooves on stone
+    smells: earthy musk, old blood and sweat
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Labyrinth Layouts
+      instructions: ''
+      table:
+        - - Intricate sewer system of the ancient capital.
+          - Thorn-choked paths hiding mischievous fey.
+          - Tunnels of a sea cave, half-filled with water.
+          - Stone paths lined with fragile mirrors.
+          - Deep stepwell with various paths cut off.
+          - Enchanted woods with shifting pathways.
+prototypeToken:
+  name: Minotaur
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368437261
+  modifiedTime: 1750368437261
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: jv4yMVAoNboAy8nc
+sort: 0
+_key: '!actors!jv4yMVAoNboAy8nc'
+

--- a/src/packs/monsters/Naga_ye9W4zCUDBoKpAac.yml
+++ b/src/packs/monsters/Naga_ye9W4zCUDBoKpAac.yml
@@ -1,0 +1,162 @@
+folder: null
+name: Naga
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Malevolent serpentine figures, guarding ancient wisdom. They defend
+    sacred groves and lost ruins with potent magic against any who dare
+    trespass.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Serpentine Grace
+    - Ancient Wisdom
+    - Speech
+  moves:
+    - Venomous Fangs
+    - Constrict
+    - Hex Magic
+  desires:
+    - value: to keep its secrets for itself, no matter the cost.
+      are: false
+    - value: to be insulted with offers, as if it can be bought.
+      are: false
+  sensories:
+    colors:
+      - name: Scaled Green
+        color: '#2e8a57'
+      - name: Reptilian Blue
+        color: '#4682b4'
+      - name: Aged Gold
+        color: '#b8860b'
+    sights: iridescent scales, gleaming eyes
+    sounds: hiss of scales sliding across stone, whispering
+    smells: exotic incense, floral notes mixed with musk
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Forbidden Knowledge
+      instructions: (Roll 3 & Interpret)
+      table:
+        - - secret
+          - twisted
+          - 'false'
+          - 'true'
+          - blasphemous
+          - shattered
+        - - scrolls of
+          - visions of
+          - rites of
+          - pacts of
+          - elixirs of
+          - ciphers of
+        - - immortality
+          - soulbinding
+          - necromancy
+          - teleportation
+          - polymorphing
+          - godhood
+prototypeToken:
+  name: Naga
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368438175
+  modifiedTime: 1750368438175
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: ye9W4zCUDBoKpAac
+sort: 0
+_key: '!actors!ye9W4zCUDBoKpAac'
+

--- a/src/packs/monsters/Nightmare_jFvT0lvRLkPfJoEJ.yml
+++ b/src/packs/monsters/Nightmare_jFvT0lvRLkPfJoEJ.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Nightmare
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Flame-wreathed steeds that emerge from the underworld, galloping through
+    the night. Their hooves leave scorched trails across the land.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Flame-wreathed
+    - Slips Between Planes
+    - Understands Language
+  moves:
+    - Hellfire Breath
+    - Shadowy Teleport
+    - Rear Up & Neigh
+  desires:
+    - value: to carry those who seek vengeance.
+      are: false
+    - value: to witness acts of mercy or kindness.
+      are: false
+  sensories:
+    colors:
+      - name: Hellfire Red
+        color: '#b22222'
+      - name: Shadow Black
+        color: '#2f2f2f'
+      - name: Ember Gray
+        color: '#484848'
+    sights: charred hoofprints, trail of smoke, glowing red eyes
+    sounds: crackle of flames, pounding of hooves, eerie neighs
+    smells: burnt sulfur, smoldering ashes
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: WRATHFUL RIDERS
+      instructions: ''
+      table:
+        - - Exiled knight, who did nothing wrong.
+          - Betrayed queen, who deserved what she got.
+          - Hanged poet, whose words rang too true.
+          - Wayward prince, who will never go home.
+          - Desperate rebel, the last one alive.
+          - Bitter seer, whose warnings were ignored.
+prototypeToken:
+  name: Nightmare
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368439140
+  modifiedTime: 1750368439140
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: jFvT0lvRLkPfJoEJ
+sort: 0
+_key: '!actors!jFvT0lvRLkPfJoEJ'
+

--- a/src/packs/monsters/Ochre_Jelly_bMdOY9D9IvSERFxO.yml
+++ b/src/packs/monsters/Ochre_Jelly_bMdOY9D9IvSERFxO.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Ochre Jelly
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Pulsing, acidic oozes that dissolve anything they touch as they silently
+    slither through dungeons. They split into smaller versions when struck.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Extremely Sticky
+    - Divides When Struck
+  moves:
+    - Slurp Forward
+    - Absorb
+    - Slink Away
+  desires:
+    - value: to grow into the greatest of all jellies.
+      are: false
+    - value: to split into new rivals.
+      are: false
+  sensories:
+    colors:
+      - name: Ochre
+        color: '#bd8a15'
+      - name: Sickly Yellow
+        color: '#cdcc00'
+      - name: Murky Brown
+        color: '#6b4226'
+    sights: unsettling motion, remnants of absorbed creatures
+    sounds: wet sloshing, faint bubbling, the quiet pull of suction
+    smells: sour decay, moldy dampness
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Newly Split Jellies (It's not sticky)
+      instructions: ''
+      table:
+        - - Azure jelly, with a freezing touch.
+          - Crimson jelly, shrieks and bleeds when it's struck.
+          - Verdant jelly, spreads carnivorous plant life.
+          - Mercury jelly, perfectly reflects its surroundings.
+          - Spectral jelly, shimmers like a mirage.
+          - Onyx jelly, leaves a trail of thick, bubbling tar.
+prototypeToken:
+  name: Ochre Jelly
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368439998
+  modifiedTime: 1750368439998
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: bMdOY9D9IvSERFxO
+sort: 0
+_key: '!actors!bMdOY9D9IvSERFxO'
+

--- a/src/packs/monsters/Ogre_qB1fsa47i27KXfxu.yml
+++ b/src/packs/monsters/Ogre_qB1fsa47i27KXfxu.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Ogre
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Towering, brutish creatures with thick skin and crude weapons. They roam
+    forests and caves, smashing anything in its path to keep itself amused.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Overwhelming Power
+    - Slow & Stubborn
+    - Speech
+  moves:
+    - Grab & Crush
+    - Raging Roar
+    - Body Slam
+  desires:
+    - value: to wander and destroy—a good life.
+      are: false
+    - value: to be outwitted by smaller creatures.
+      are: false
+  sensories:
+    colors:
+      - name: Rustin Tan
+        color: '#8a5a2a'
+      - name: Dirty Brown
+        color: '#a0522c'
+      - name: Forest Green
+        color: '#4e6b4d'
+    sights: towering silhouette in the trees, gnarled club
+    sounds: heavy footfalls, low growls
+    smells: stale sweat, dirt, lingering scent of raw meat
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Chosen Leader of The ...
+      instructions: ''
+      table:
+        - - Trolls, after marrying their chieftain.
+          - Hill goblins, fearing its wrath.
+          - Swamp spirits, bound to its will.
+          - Wild fey, attracted by its savagery.
+          - Hill giants, who think it's a genius.
+          - Other ogres, a small army of them.
+prototypeToken:
+  name: Ogre
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368441407
+  modifiedTime: 1750368441407
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: qB1fsa47i27KXfxu
+sort: 0
+_key: '!actors!qB1fsa47i27KXfxu'
+

--- a/src/packs/monsters/Otyugh_csUbInPXTy015oPl.yml
+++ b/src/packs/monsters/Otyugh_csUbInPXTy015oPl.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Otyugh
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Grotesque, tentacled scavengers lurking in sewers and refuse heaps. They
+    devour rotting carcasses and overwhelm any disturbance with diseased
+    filth.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Diseased Touch
+    - Reeking Stench
+    - Understands, Telepathy
+  moves:
+    - Spray Filth
+    - Putrid Gulp
+    - Sludge Tentacle
+  desires:
+    - value: to strike simple truces for territory.
+      are: false
+    - value: for its accumulated filth to be washed clean.
+      are: false
+  sensories:
+    colors:
+      - name: Putrid Brown
+        color: '#6b4226'
+      - name: Sewer Green
+        color: '#566b30'
+      - name: Rotten Flesh
+        color: '#8a7d6c'
+    sights: slimy tentacles, rotting filth, scattered bones
+    sounds: squishy movements, wet gurgles, buzzing flies
+    smells: putrid rot, decay, stagnant swamp water
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Filthy Accomplices
+      instructions: ''
+      table:
+        - - Spewing animated fungus swarms.
+          - Driven forward by a cult of ruin.
+          - Controlled by city sanitation workers.
+          - Followed by a horde of plague-ridden rats.
+          - Ridden by a foul goblin shaman.
+          - Possessed by a fallen druid's spirit.
+prototypeToken:
+  name: Otyugh
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368442259
+  modifiedTime: 1750368442259
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: csUbInPXTy015oPl
+sort: 0
+_key: '!actors!csUbInPXTy015oPl'
+

--- a/src/packs/monsters/Owlbear_TOInH4dokRTwAAzC.yml
+++ b/src/packs/monsters/Owlbear_TOInH4dokRTwAAzC.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Owlbear
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fiercely territorial, hulking beasts with the body of a bear and head of
+    an owl. They hunt in forests, using their keen senses and raw power.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Nocturnal Hunter
+    - Lumbering Speed
+  moves:
+    - Territorial Roar
+    - Crushing Beak
+    - Piercing Screech
+  desires:
+    - value: to protect its territory.
+      are: false
+    - value: any threat to its nesting cave.
+      are: false
+  sensories:
+    colors:
+      - name: Tawny Feather
+        color: '#d1b48c'
+      - name: Furry Brown
+        color: '#8b4512'
+      - name: Talon Slate
+        color: '#708090'
+    sights: towering silhouette in the trees, gnarled club
+    sounds: heavy footfalls, low growls
+    smells: stale sweat, dirt, lingering scent of raw meat
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Victims, still fresh
+      instructions: ''
+      table:
+        - - Scholar, face down, drawings strewn about.
+          - Cultist, dead in a tree without a scratch on them.
+          - Messenger, half-eaten scroll in hand.
+          - Farmer, holding a wilted bouquet.
+          - Smuggler, clutching a vial of purple poison.
+          - Performer, in full costume, mask still on.
+prototypeToken:
+  name: Owlbear
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368443150
+  modifiedTime: 1750368443150
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: TOInH4dokRTwAAzC
+sort: 0
+_key: '!actors!TOInH4dokRTwAAzC'
+

--- a/src/packs/monsters/Pegasus_htxmxZ2Yjvgy2twS.yml
+++ b/src/packs/monsters/Pegasus_htxmxZ2Yjvgy2twS.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Pegasus
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Majestic, winged horses with a noble spirit. They soar through the skies,
+    drawn to those with courage and kindess, appearing in moments of dire
+    need.</p>
+  notes: ''
+  role: protector
+  tier: tough
+  traits:
+    - Graceful Flier
+    - Pure-hearted
+    - Understands Language
+  moves:
+    - Winged Charge
+    - Wing Buffet
+    - Celestial Whinny
+  desires:
+    - value: to come to aid in dire moments.
+      are: false
+    - value: to be ridden.
+      are: false
+  sensories:
+    colors:
+      - name: Silver Gray
+        color: '#c0c0c0'
+      - name: Sky Blue
+        color: '#b0c4dd'
+      - name: Cloud White
+        color: '#e4e7ec'
+    sights: shimmering feathers, graceful gait
+    sounds: powerful wing beats, soft neighing, wind rushing
+    smells: fresh air, faint scent of wildflowers
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Carried Messages
+      instructions: ''
+      table:
+        - - Royal summons, sealed with enchanted wax.
+          - Love letter filled with terrible poetry.
+          - Battle plan hastily scrawled.
+          - Desperate plea from a sworn enemy.
+          - Ransom note tied with black string.
+          - Official declaration of invasion.
+prototypeToken:
+  name: Pegasus
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368443999
+  modifiedTime: 1750368443999
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: htxmxZ2Yjvgy2twS
+sort: 0
+_key: '!actors!htxmxZ2Yjvgy2twS'
+

--- a/src/packs/monsters/Phoenix_b84JWSCofsFYOp2E.yml
+++ b/src/packs/monsters/Phoenix_b84JWSCofsFYOp2E.yml
@@ -1,0 +1,156 @@
+folder: null
+name: Phoenix
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Mythical birds of fire, emerging to bring both destruction and new
+    beginnings. As they blaze across the sky, their embers spread cleansing
+    infernos.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Radiates Intense Heat
+    - Reborn Upon Death
+    - Speech
+  moves:
+    - Flame Burst
+    - Ember Trail
+    - Call Firestorm
+  desires:
+    - value: to only come when they're needed most.
+      are: false
+    - value: to face the pain and horror of its rebirth.
+      are: false
+  sensories:
+    colors:
+      - name: Inferno Gold
+        color: '#daa521'
+      - name: Flaming Orange
+        color: '#d63900'
+      - name: Ash Gray
+        color: '#bebebe'
+    sights: fiery wings, glowing ember trails, vibrant plumage
+    sounds: crackling flames, occasional soft cooing
+    smells: warm ash, hints of sulfur, sweet smokiness
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Alchemical Powers
+      instructions: (Roll 2 per part secured)
+      table:
+        - - Immunity to fire
+          - Cure any disease
+          - Massive, fiery wings
+          - Resurrection
+          - Telepathy
+          - Summon firelings
+        - - Flaming Touch
+          - Slip between realities
+          - Fiery rebuke aura
+          - Cinder trail
+          - Flame divination
+          - Blazing speed
+prototypeToken:
+  name: Phoenix
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368447217
+  modifiedTime: 1750368447217
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: b84JWSCofsFYOp2E
+sort: 0
+_key: '!actors!b84JWSCofsFYOp2E'
+

--- a/src/packs/monsters/Rakshasa_aHh9l8aifIetBvWq.yml
+++ b/src/packs/monsters/Rakshasa_aHh9l8aifIetBvWq.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Rakshasa
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Cunning, tiger-headed fiends with reversed hands that revel in wealth and
+    opulence. They manipulate mortals with illusions and lies, gaining great
+    power.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Illusion Magic
+    - Elegant Manipulator
+    - Speech
+  moves:
+    - Enchant Person
+    - Illusions
+    - Perfect Lies
+  desires:
+    - value: to surround itself in luxury.
+      are: false
+    - value: for crude company to sully its refined tastes.
+      are: false
+  sensories:
+    colors:
+      - name: Silken Gold
+        color: '#c0a057'
+      - name: Regal Purple
+        color: '#4b0081'
+      - name: Tiger Orange
+        color: '#d66a2c'
+    sights: ornate clothing, well-groomed fur
+    sounds: smooth voice, rustle of silk, faintly echoing footsteps
+    smells: incense, hints of expensive perfumes
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Influence Networks
+      instructions: ''
+      table:
+        - - Thieves guild. Fits in perfectly.
+          - Merchant coalition. Sold their soul for it.
+          - Pirate fleet. Won it in a duel.
+          - Noble house. Happily married into it.
+          - Mercenary band. Controls it from afar.
+          - Spy ring. Works for four different sides.
+prototypeToken:
+  name: Rakshasa
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368448096
+  modifiedTime: 1750368448096
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: aHh9l8aifIetBvWq
+sort: 0
+_key: '!actors!aHh9l8aifIetBvWq'
+

--- a/src/packs/monsters/Remorhaz_ll9AHG8iIeAHViG0.yml
+++ b/src/packs/monsters/Remorhaz_ll9AHG8iIeAHViG0.yml
@@ -1,0 +1,316 @@
+folder: null
+name: Remorhaz
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, heat-radiating worms with red-hot spines along their back. They
+    burrow through frozen tundra, devouring all in their path with searing
+    jaws.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Radiates Intense Heat
+    - Swift Burrower
+    - Powerful Mandibles
+  moves:
+    - Emerging Strike
+    - Heat Wave
+    - Devour
+  desires:
+    - value: to find hot springs or lava flows to lay its eggs.
+      are: false
+    - value: to feel the cold seep under its carapace.
+      are: false
+  sensories:
+    colors:
+      - name: Serpentine Blue
+        color: '#5e9ea0'
+      - name: Molten Red
+        color: '#b22222'
+      - name: Chitin Gray
+        color: '#a9a9a9'
+    sights: glowing red-hot spines, icy blue eyes, sharp ridges
+    sounds: hissing steam, grinding mandibles, cracking ice
+    smells: burnt metal, scorched earth, sulfur
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Worms of Dark Prophecy
+      instructions: ''
+      table:
+        - - Rouse the Slumbering Gods Entombed.
+          - Sever the Sacred Bonds of Blood and Root.
+          - Devour the Heart of the Hero Foretold.
+          - Unseal the Crypt of the Nameless King.
+          - Torch the Roots of the World Tree.
+          - Silence the Bells of the Eternal City.
+prototypeToken:
+  name: Remorhaz
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items:
+  - name: Tail
+    type: challenge
+    _id: GVRpXbnMy6HzUe0U
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Erratic, flicking tail
+        - Few handholds
+      moves:
+        - Flying Ice Shards
+        - Tail Hits Wall
+      failure:
+        - pool:
+            diceNum: 8
+            max: null
+          value: ✘ It notices you (shared across challenges)
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ll9AHG8iIeAHViG0.GVRpXbnMy6HzUe0U'
+  - name: Midsection
+    type: challenge
+    _id: n3ssZrE3i23jnV3Z
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Red hot spines
+        - Few cool spots
+      moves:
+        - Shimmering Haze
+        - Sudden Turn
+      failure:
+        - pool:
+            diceNum: 8
+            max: null
+          value: ✘ It notices you (shared across challenges)
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ll9AHG8iIeAHViG0.n3ssZrE3i23jnV3Z'
+  - name: Flared Hood
+    type: challenge
+    _id: gCKfgDcFdP82UyY0
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 4
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - Wide plates
+        - Loose scales
+      moves:
+        - Swift Head Turn
+        - Swallow Prey
+      failure:
+        - pool:
+            diceNum: 8
+            max: null
+          value: ✘ It notices you (shared across challenges)
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ll9AHG8iIeAHViG0.gCKfgDcFdP82UyY0'
+  - name: Ice Canyon Threats
+    type: challenge
+    _id: eH1rOkJoet1vn62M
+    img: icons/svg/item-bag.svg
+    system:
+      description: ''
+      roll:
+        diceNum: 0
+        max: null
+      pool:
+        diceNum: 0
+        max: null
+      suspense:
+        steps:
+          - true
+          - true
+      traits:
+        - 4d Gusting Winds
+        - 6d Collapsing walls
+      moves: []
+      failure: []
+    effects: []
+    folder: null
+    sort: 0
+    ownership:
+      default: 0
+      jgipq2YBy9KMjQWt: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      exportSource: null
+      coreVersion: '13.345'
+      systemId: grimwild
+      systemVersion: 0.1.7
+      lastModifiedBy: null
+    _key: '!actors.items!ll9AHG8iIeAHViG0.eH1rOkJoet1vn62M'
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368449027
+  modifiedTime: 1750368449027
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: ll9AHG8iIeAHViG0
+sort: 0
+_key: '!actors!ll9AHG8iIeAHViG0'
+

--- a/src/packs/monsters/Roc_gpizIRWsGj1Jd0lh.yml
+++ b/src/packs/monsters/Roc_gpizIRWsGj1Jd0lh.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Roc
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Colossal birds with wings that block out the sun. They appear in times of
+    stagnation to bring change by carrying away that which no longer
+    belongs.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Blocks Out The Sun
+    - Impervious To Damage
+  moves:
+    - Gale Force Winds
+    - Talon Grasp
+    - Swallow Whole
+  desires:
+    - value: to return to its nest.
+      are: false
+    - value: to be distracted from what it must do.
+      are: false
+  sensories:
+    colors:
+      - name: Feathered Sand
+        color: '#d1b48c'
+      - name: Dusty Brown
+        color: '#7d6244'
+      - name: Stormy Blue
+        color: '#6a7b8b'
+    sights: as big as the clouds, vast silhouette on the horizon
+    sounds: resonating wingbeats, massive gusts of wind
+    smells: overwhelming earthy musk, dry feathers
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Potential Egg Buyers
+      instructions: ''
+      table:
+        - - Dying empress, who will feed on it to live.
+          - Dragon, who will use it to barter for its life.
+          - Ancient lich, who will create its greatest minion.
+          - Storm giant, who will raise it as a mount.
+          - Infamous pirate, who sees it as a future skyship.
+          - Druidic order, who will unleash it on the world.
+prototypeToken:
+  name: Roc
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368450031
+  modifiedTime: 1750368450031
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: gpizIRWsGj1Jd0lh
+sort: 0
+_key: '!actors!gpizIRWsGj1Jd0lh'
+

--- a/src/packs/monsters/Roper_N9TCgv9NICq4r2PR.yml
+++ b/src/packs/monsters/Roper_N9TCgv9NICq4r2PR.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Roper
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Lurking predators in caverns, blending with stalagmites to ambush prey.
+    Their tendrils drag victims in for a deadly bite, leaving escape nearly
+    impossible.</p>
+  notes: ''
+  role: lurker
+  tier: tough
+  traits:
+    - Cave Camouflage
+    - Extended Tendrils
+    - Speech
+  moves:
+    - Survive Scrutiny
+    - Reel In
+    - Cause Paranoia
+  desires:
+    - value: to strike lone targets.
+      are: false
+    - value: to be scrutinized and revealed.
+      are: false
+  sensories:
+    colors:
+      - name: Cave Earth
+        color: '#8b4512'
+      - name: Rocky Gray
+        color: '#696969'
+      - name: Slate Brown
+        color: '#4b3621'
+    sights: tendril shadows, unremarkable stalagmites
+    sounds: low rumbling growl, rocky slithering
+    smells: earthy stone, dank moss, faint rotting flesh
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: How it survives scrutiny
+      instructions: ''
+      table:
+        - - Mimics dripping water, distant echoes.
+          - Moves incredibly quickly when not watched.
+          - Makes you feel like you are being watched.
+          - Absorbs light, creating longer shadows.
+          - Stays deathly still, even under attack.
+          - Leaves no trace of its previous meals.
+prototypeToken:
+  name: Roper
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368450957
+  modifiedTime: 1750368450957
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: N9TCgv9NICq4r2PR
+sort: 0
+_key: '!actors!N9TCgv9NICq4r2PR'
+

--- a/src/packs/monsters/Rustmaw_7RplB5bD7lao5R1z.yml
+++ b/src/packs/monsters/Rustmaw_7RplB5bD7lao5R1z.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Rustmaw
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Chitinous creatures that feed on metal, rusting weapons and armor with a
+    touch. Their twitching antannae guide them straight to their next metallic
+    meal.</p>
+  notes: ''
+  role: skirmisher
+  tier: tough
+  traits:
+    - Rusts Metal It Touches
+    - Hard Carapace
+  moves:
+    - Skitter and Hide
+    - Eat Weapon
+    - Twitch Atennae
+  desires:
+    - value: to consume every last trace of metal.
+      are: false
+    - value: to accidentally munch on wood or glass.
+      are: false
+  sensories:
+    colors:
+      - name: Metal Decay
+        color: '#b1723f'
+      - name: Corroded Umber
+        color: '#c5503e'
+      - name: Oxide Red
+        color: '#8b0101'
+    sights: twitching antennae, scattered rust crumbs
+    sounds: scraping mandibles, rustling movement
+    smells: sharp metallic tang, faint odor of decay
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Residual Effects of Eating Arcana
+      instructions: ''
+      table:
+        - - Glows in the dark.
+          - Leaves a trail of sparks behind it.
+          - Floats slightly above the ground.
+          - Speaks in very basic terms.
+          - Vibrates like a tuning fork when struck.
+          - Is completely invisible.
+prototypeToken:
+  name: Rustmaw
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368451905
+  modifiedTime: 1750368451905
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 7RplB5bD7lao5R1z
+sort: 0
+_key: '!actors!7RplB5bD7lao5R1z'
+

--- a/src/packs/monsters/Shambling_Mound_WLlxvScZ50x03zi3.yml
+++ b/src/packs/monsters/Shambling_Mound_WLlxvScZ50x03zi3.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Shambling Mound
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Hulking masses of vines and swamp muck lumbering through marshes. They
+    engulf prey and grow larger with each and every victim.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Absorbs And Grows
+    - Swampy Camouflage
+  moves:
+    - Regrowth
+    - Vine Lash
+    - Engulf
+  desires:
+    - value: to find and consume prosperity.
+      are: false
+    - value: to consume desiccated creatures.
+      are: false
+  sensories:
+    colors:
+      - name: Vine Green
+        color: '#566b30'
+      - name: Muck Brown
+        color: '#4b3621'
+      - name: Rotting Green
+        color: '#395f0a'
+    sights: mass of tangled vines, streaks in the muck
+    sounds: wet sloshing, cracking branches, earthy groan
+    smells: rotting vegetation, swamp muck, wet earth
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Buried Within
+      instructions: ''
+      table:
+        - - Grand druid, sleeping within a cocoon.
+          - Ancient coffin, sealing away a cursed vampire.
+          - Nearly endless amount of animated skeletons.
+          - Mask of twisted vines that whispers riddles.
+          - Fey gateway, pulsing with otherwordly energy.
+          - Warbanner of the true queen.
+prototypeToken:
+  name: Shambling Mound
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368452835
+  modifiedTime: 1750368452835
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: WLlxvScZ50x03zi3
+sort: 0
+_key: '!actors!WLlxvScZ50x03zi3'
+

--- a/src/packs/monsters/Sphinx_h8hzuAzUEFtPUmHP.yml
+++ b/src/packs/monsters/Sphinx_h8hzuAzUEFtPUmHP.yml
@@ -1,0 +1,173 @@
+folder: null
+name: Sphinx
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Majestic creatures with the body of a lion and head of a human. They
+    guard secrets and grant wishes, testing people with riddles to prove their
+    worth.</p>
+  notes: ''
+  role: tactician
+  tier: tough
+  traits:
+    - Master of Riddles
+    - Unfooled by Deception
+    - Speech
+  moves:
+    - Wing Buffet
+    - Divination Spell
+    - Teleport
+  desires:
+    - value: to allow the truly worthy to pass by.
+      are: false
+    - value: to face trickery or deception of any kind.
+      are: false
+  sensories:
+    colors:
+      - name: Ancient Gold
+        color: '#b8860b'
+      - name: Dusky Blue
+        color: '#49646b'
+      - name: Desert Sand
+        color: '#d1b48c'
+    sights: golden fur, regal posture, watchful eyes
+    sounds: resonant voice, wind sweeping by, distant roars
+    smells: warm sand, ancient incense, faint floral scents
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Wish Choices
+      instructions: ''
+      table:
+        - - Ask any yes or no question.
+          - Ask for any one item and it is yours.
+          - Ask to be any age you would like—forever?
+          - Ask for any one being to cease to be.
+          - Ask for any one being to be brought back.
+          - Ask for a chance to correct a single regret.
+    - name: Riddle
+      instructions: >-
+        Roll 3, choose 1 or 2, pose it as a riddle (if relatively close, accept
+        it. combine two for a tough riddle.)
+      table:
+        - - It flows but has no shape
+          - It grows taller, then vanishes.
+          - It travels far but takes no steps.
+          - It burns but leaves no ashes.
+          - It counts the moments but has no hands.
+          - It falls but makes no sound.
+        - - It's cold but not frozen.
+          - It's bright but not hot.
+          - It hums when the world is still.
+          - It's full but never complete.
+          - It's fleeting but always returns.
+          - It's hidden in plain sight.
+        - - It grows when light dims.
+          - It follows you on sunny days.
+          - It stares back from still waters.
+          - It's buried but not dead.
+          - It's a silent companion.
+          - It's a path without end.
+prototypeToken:
+  name: Sphinx
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368453713
+  modifiedTime: 1750368453713
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: h8hzuAzUEFtPUmHP
+sort: 0
+_key: '!actors!h8hzuAzUEFtPUmHP'
+

--- a/src/packs/monsters/Troll_iOMIQa15K1way7RZ.yml
+++ b/src/packs/monsters/Troll_iOMIQa15K1way7RZ.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Troll
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Regenerating creatures that lair in overlooked places, hoarding strange
+    trophies. They make simple demands and usually negotiate before cracking
+    skulls.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Regenerates
+    - Weak vs. Fire, Acid
+    - Speech (Grunts, Gestures)
+  moves:
+    - Convincing Offer
+    - Hurl Enemy
+    - Topple Trees
+  desires:
+    - value: its lair to be filled with bones and trophies.
+      are: false
+    - value: to let on that it's more cunning than it looks.
+      are: false
+  sensories:
+    colors:
+      - name: Earthy Brown
+        color: '#8b4512'
+      - name: Granite Gray
+        color: '#696969'
+      - name: Muddy Green
+        color: '#6a8e22'
+    sights: an oddly shaped mound, glint of sharp claws
+    sounds: low grumbling, crunch of bones, wet chewing
+    smells: stale swamp water, wet fur, strong musk of mold
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Overlooked Lairs
+      instructions: ''
+      table:
+        - - Abandoned mill, half-sunk in the swamp.
+          - Ruined bathhouse, flooded with muck.
+          - Crumbling fort lost in dense woods.
+          - Hollowed-out tree astride a grain field.
+          - Ruined chapel overtaken by brambles.
+          - Rocky cave behind a waterfall.
+prototypeToken:
+  name: Troll
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368454557
+  modifiedTime: 1750368454557
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: iOMIQa15K1way7RZ
+sort: 0
+_key: '!actors!iOMIQa15K1way7RZ'
+

--- a/src/packs/monsters/Undead__Ghast_kDFZqpFehl8Agl2r.yml
+++ b/src/packs/monsters/Undead__Ghast_kDFZqpFehl8Agl2r.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Undead, Ghast
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Rotting corpses driven by an ancient plague that wishes to spread once
+    more. They're full of hunger and rage, and leave victims messily scattered
+    about.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Rotting Stench
+    - Plague Carrier
+    - Speech (Archaic)
+  moves:
+    - Putrid Exhale
+    - Festering Claws
+    - Numbing Grasp
+  desires:
+    - value: to feed, inadvertently spreading the plague.
+      are: false
+    - value: to give up on a fleshy meal.
+      are: false
+  sensories:
+    colors:
+      - name: Weathered Flesh
+        color: '#8a7d6c'
+      - name: Decayed Green
+        color: '#395f0a'
+      - name: Bloodstain Red
+        color: '#7c0902'
+    sights: pallid skin, jagged teeth, bloated and yellowed
+    sounds: guttural snarls, heavy breathing, slap of bare feet
+    smells: decayed flesh, sour stench, mold
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Bygone Plagues
+      instructions: ''
+      table:
+        - - The Weeping Rot, turning flesh to black ooze.
+          - The Crimson Blight, causing veins to burst.
+          - The Ashen Grip, hardening limbs into stone.
+          - The Vile Verdancy, growing plants from wounds.
+          - The Choking Miasma, filling lungs with sludge.
+          - The Thorned Decay, sprouting barbs from skin.
+prototypeToken:
+  name: Undead, Ghast
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368455423
+  modifiedTime: 1750368455423
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: kDFZqpFehl8Agl2r
+sort: 0
+_key: '!actors!kDFZqpFehl8Agl2r'
+

--- a/src/packs/monsters/Undead__Ghost_A3tBMJpVysqXej3I.yml
+++ b/src/packs/monsters/Undead__Ghost_A3tBMJpVysqXej3I.yml
@@ -1,0 +1,162 @@
+folder: null
+name: Undead, Ghost
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Spectral entities bound to the mortal realm, haunting familiar places and
+    reliving past moments. Their presence terrifies all who witness their
+    sorrow.</p>
+  notes: ''
+  role: blaster
+  tier: tough
+  traits:
+    - Ethereal Form
+    - Anchored Spirit
+    - Speech
+  moves:
+    - Shared Memories
+    - Wail of Sorrow
+    - Spirit Siphon
+  desires:
+    - value: to do something, if only it could remember what.
+      are: false
+    - value: for its presence to go unnoticed.
+      are: false
+  sensories:
+    colors:
+      - name: Spirit Silver
+        color: '#c0c0c0'
+      - name: Pale Mist
+        color: '#d7bfd7'
+      - name: Misty Blue
+        color: '#b0c4dd'
+    sights: fading in and out, subtly shifting, drifting figure
+    sounds: faint sobs, echoing footsteps, an occasional scream
+    smells: old books, lavender, childhood memories
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Unfinished Business
+      instructions: Roll 3d6, interpret
+      table:
+        - - heirloom
+          - estate
+          - portrait
+          - key
+          - diary
+          - relic
+        - - confession
+          - vow
+          - denial
+          - hidden
+          - whisper
+          - promise
+        - - vendetta
+          - guilt
+          - betrayal
+          - murder
+          - burden
+          - obsession
+prototypeToken:
+  name: Undead, Ghost
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: null
+  bar2:
+    attribute: null
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 0
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368456730
+  modifiedTime: 1750368456730
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: A3tBMJpVysqXej3I
+sort: 0
+_key: '!actors!A3tBMJpVysqXej3I'
+

--- a/src/packs/monsters/Undead__Lich_L14dmMrOg6AW2jBf.yml
+++ b/src/packs/monsters/Undead__Lich_L14dmMrOg6AW2jBf.yml
@@ -1,0 +1,163 @@
+folder: null
+name: Undead, Lich
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Immortal magicians driven by a singular, dark purpose. They control
+    hordes of undead from a well-defended lair, executing schemes with cold
+    calculation.</p>
+  notes: >-
+    <p>Lich Spellbooks</p><p style="text-align:center">A lich knows 8 wizard
+    spells. Choose a spellbook below, or make one. They gain 1 bonus suspense
+    for each spell.</p><p></p><p><span style="text-decoration:underline"><span
+    style="text-decoration:underline">Spellbook 1</span></span></p><p>Slow Worm
+    - Transmutation</p><p>Pain Cascade - Necromancy</p><p>Screaming Aura -
+    Enchantment</p><p>Mesmerising Mask - Illusion</p><p></p><p>Mind Guide -
+    Divination</p><p>Flesh Beacon - Transmutation</p><p>Oil Shield -
+    Abjuration</p><p>Bone Wall - Conjuration</p><p></p><p><span
+    style="text-decoration:underline">Spellbook 2</span></p><p>Expanding Flesh -
+    Transmutation</p><p>Hungry Wings - Conjuration</p><p>Dazzling Vine -
+    Illusion</p><p>Terrible Lore - Divination</p><p></p><p>Slow Chains -
+    Transmutation</p><p>Binding Word - Enchantment</p><p>Prismatic Smoke -
+    Evocation</p><p>Hungry Terror - Necromancy</p>
+  role: overseer
+  tier: tough
+  traits:
+    - 8 Wizard Spells
+    - Two Steps Ahead
+    - Speech
+  moves:
+    - Cast Spell
+    - Raise Undead
+    - Soul Leech
+  desires:
+    - value: to obtain the power it needs for its grand scheme.
+      are: false
+    - value: anything near its phylactery.
+      are: false
+  sensories:
+    colors:
+      - name: Ancient Purple
+        color: '#4b0081'
+      - name: Rotten Green
+        color: '#566b30'
+      - name: Bone White
+        color: '#e6e1ce'
+    sights: tattered robes, skeletal hands, piercing eyes
+    sounds: hoarse incantations, eerie silence between words
+    smells: ancient dust, burnt incense, sharp cloying decay
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Overly Grandiose Dark Rituals
+      instructions: ''
+      table:
+        - - Enslave every soul in the realm to its will.
+          - Steal the life essence of the royal bloodline.
+          - Summon the Bonegrinder, eater of legends.
+          - Sing the song that will end the world.
+          - Raise a necropolis from which to rule.
+          - Twist the vast forests into a maze of undead trees.
+prototypeToken:
+  name: Undead, Lich
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368457200
+  modifiedTime: 1750368457200
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: L14dmMrOg6AW2jBf
+sort: 0
+_key: '!actors!L14dmMrOg6AW2jBf'
+

--- a/src/packs/monsters/Undead__Vampire_Jfb9j3CmHM2ia3Tz.yml
+++ b/src/packs/monsters/Undead__Vampire_Jfb9j3CmHM2ia3Tz.yml
@@ -1,0 +1,184 @@
+folder: null
+name: Undead, Vampire
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Elegant, nocturnal hunters driven by a thirst for blood. They seamlessly
+    integrate into society, all while avoiding daylight at all costs.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Unnatural Allure
+    - Supernatural Strength
+    - Speech
+  moves:
+    - Blood Drain
+    - Regeneration
+    - Reveal Teeth
+  desires:
+    - value: to pursue its desires, with no end-goal in mind.
+      are: false
+    - value: to be reminded of when it was mortal.
+      are: false
+  sensories:
+    colors:
+      - name: Deep Crimson
+        color: '#7c0902'
+      - name: Midnight Black
+        color: '#2f2f2f'
+      - name: Moonlit Ivory
+        color: '#e1d9c2'
+    sights: flickering candelight, blood-stained velvet
+    sounds: soft whispers, the rustle of fabric
+    smells: old blood, faint rose perfume
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Siring Intentions
+      instructions: ''
+      table:
+        - - Punish them for betraying your trust.
+          - Offer them a twisted redemption.
+          - Teach them the vanity of mortal life.
+          - Preserve their forbidden love.
+          - Trap them in unending regret.
+          - Use them to control those they once loved.
+    - name: From Hero to Vampire
+      instructions: >-
+        Roll 2d6 (pick 1) for path/core. Roll 1d8 and count on their talent list
+        (on 8, roll 2d8). Adapt as traits and moves.
+      table:
+        - - Bard
+          - Berserker
+          - Cleric
+          - Druid
+          - Fighter
+          - Monk
+        - - Paladin
+          - Ranger
+          - Rogue
+          - Sorcerer
+          - Warlock
+          - Wizard
+    - name: Power
+      instructions: For every 50 years of unlife, roll a new power.
+      table:
+        - - Bat, mist, or wolf form
+          - Mesmerising Gaze
+          - Cling to walls
+          - Preternatural speed
+          - Lifesense
+          - Call vermin
+    - name: Weakness
+      instructions: For every 50 years of unlife, roll a new weakness.
+      table:
+        - - Holy symbols
+          - Garlic
+          - Running water
+          - Lacking reflection
+          - Invitation only
+          - Extreme thirst
+prototypeToken:
+  name: Undead, Vampire
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368458101
+  modifiedTime: 1750368458101
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: Jfb9j3CmHM2ia3Tz
+sort: 0
+_key: '!actors!Jfb9j3CmHM2ia3Tz'
+

--- a/src/packs/monsters/Undead__Wight_IkvcjajHy2CNp6k4.yml
+++ b/src/packs/monsters/Undead__Wight_IkvcjajHy2CNp6k4.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Undead, Wight
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Risen corpses consumed by hatred, wielding cursed weapons to drain life
+    from their foes. They defend their domains with unrelenting malice.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Regenerative Strikes
+    - Victims Become Wights
+    - Speech (Wheezes, Gasps)
+  moves:
+    - Destroy Bonds
+    - Raise Undead
+    - Sense Life
+  desires:
+    - value: to forever defend its final resting place.
+      are: false
+    - value: to face that which caused its undying hatred.
+      are: false
+  sensories:
+    colors:
+      - name: Void Black
+        color: '#030303'
+      - name: Ghostly White
+        color: '#dcdcdc'
+      - name: Deathly Gray
+        color: '#696969'
+    sights: glowing red eyes, corroded armor
+    sounds: groaning breaths, rusty clinking of ancient weapons
+    smells: damp earth, rot, stale air
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Cursed Armaments
+      instructions: ''
+      table:
+        - - Heartstealer, a blade that drains courage.
+          - Mindpiercer, a spear that devours memories.
+          - Blackhelm, a helm that compels obedience.
+          - Soulcrusher, a mace that fills with dread.
+          - Rise, a sword that raises new wights.
+          - Wailer, a spiked chain that binds spirits to it.
+prototypeToken:
+  name: Undead, Wight
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368459079
+  modifiedTime: 1750368459079
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: IkvcjajHy2CNp6k4
+sort: 0
+_key: '!actors!IkvcjajHy2CNp6k4'
+

--- a/src/packs/monsters/Undead__Wraith_LE3TdfGhTsKh5U8t.yml
+++ b/src/packs/monsters/Undead__Wraith_LE3TdfGhTsKh5U8t.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Undead, Wraith
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Shadowy, spectral figures formed of pure volatile lament. They glide
+    silently through the darkness, draining warmth from everything they
+    touch.</p>
+  notes: ''
+  role: marauder
+  tier: tough
+  traits:
+    - Incorporeal Form
+    - Deathly Cold Aura
+    - Speech
+  moves:
+    - Draining Touch
+    - Shadow Melf
+    - Wail of Despair
+  desires:
+    - value: for others to feel the emotions that formed it.
+      are: false
+    - value: for true joy to cut through its malice.
+      are: false
+  sensories:
+    colors:
+      - name: Shadowy Purple
+        color: '#3e3a6d'
+      - name: Foggy Gray
+        color: '#a9a9a9'
+      - name: Ghastly Blue
+        color: '#6a7b8b'
+    sights: swirling mist, flickering blue light
+    sounds: eerie wails, distant rustle of air, faint whispers
+    smells: frigid air, damp stone, metallic tang of fear
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Horrific Origins
+      instructions: ''
+      table:
+        - - Untold number of dead from the war.
+          - Royal court and family massacred during a coup.
+          - Serial killer's decades long reign of terror.
+          - Massacre of innocent "monstrous" village.
+          - Plague spread by one person jumping ship.
+          - Community's noble sacrifice going unnoticed.
+prototypeToken:
+  name: Undead, Wraith
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368460285
+  modifiedTime: 1750368460285
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: LE3TdfGhTsKh5U8t
+sort: 0
+_key: '!actors!LE3TdfGhTsKh5U8t'
+

--- a/src/packs/monsters/Underscourge_jlIzhItvDbRvC09L.yml
+++ b/src/packs/monsters/Underscourge_jlIzhItvDbRvC09L.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Underscourge
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Burrowing creatures with chitin armor and hypnotic eyes. They strike from
+    below, collapsing the ground to trap victims.</p>
+  notes: ''
+  role: tactician
+  tier: tough
+  traits:
+    - Burrows Effortlessly
+    - Tough Chitin
+    - Speech
+  moves:
+    - Hypnotic Gaze
+    - Rapid Burrowing
+    - Collapse Ground
+  desires:
+    - value: to feast on surface creatures.
+      are: false
+    - value: to venture into the sunlight.
+      are: false
+  sensories:
+    colors:
+      - name: Chitin Bronze
+        color: '#cd8032'
+      - name: Earthen Ochre
+        color: '#8a5a2a'
+      - name: Stone Ochre
+        color: '#b29655'
+    sights: large burrow holes, cracked earth, glistening chitin
+    sounds: distant rumbling, shifting soil, clicking mandibles
+    smells: fresh-turned earth, mineral-rich tang, earthy musk
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Collapses ...
+      instructions: ''
+      table:
+        - - Farmer’s pasture, full of cows.
+          - Town square during a festival.
+          - Noble’s garden, during a feast.
+          - Bustling mine, just as they struck the motherlode.
+          - General's tent, after a glorious victory.
+          - Royal cemetery, as the king is laid to rest.
+prototypeToken:
+  name: Underscourge
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368462538
+  modifiedTime: 1750368462538
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: jlIzhItvDbRvC09L
+sort: 0
+_key: '!actors!jlIzhItvDbRvC09L'
+

--- a/src/packs/monsters/Unicorn_OC1Blm81adIG54Rr.yml
+++ b/src/packs/monsters/Unicorn_OC1Blm81adIG54Rr.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Unicorn
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Graceful, magical horses with a single spiraling horn. They roam ancient
+    forests, bestowing healing, light, and blessings to those with pure
+    hearts.</p>
+  notes: ''
+  role: protector
+  tier: tough
+  traits:
+    - Pure Spirit
+    - Protected by Nature
+    - Understands, Telepathy
+  moves:
+    - Healing Touch
+    - Blessing
+    - Luminous Horn
+  desires:
+    - value: to keep the few true purities in the world unspoiled.
+      are: false
+    - value: to sense malevolence in a creature's heart.
+      are: false
+  sensories:
+    colors:
+      - name: Dusky Lavender
+        color: '#7e5a9a'
+      - name: Pale Rose
+        color: '#c08081'
+      - name: Verdant Mint
+        color: '#4a6f44'
+    sights: calming glow, prinstine fur, faint sparkles
+    sounds: soft clip-clop, soft whinny, soothing hum of magic
+    smells: whiff of lavender, morning dew, ancient woods
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Blessings
+      instructions: ''
+      table:
+        - - Five more healthy years of old age.
+          - Sixth sense for when you're being deceived.
+          - Immunity to poisons and diseases.
+          - You can understand any language.
+          - Cleanse any water you touch of impurities.
+          - Always know the direction to home.
+prototypeToken:
+  name: Unicorn
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368463526
+  modifiedTime: 1750368463526
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: OC1Blm81adIG54Rr
+sort: 0
+_key: '!actors!OC1Blm81adIG54Rr'
+

--- a/src/packs/monsters/Will_O__Wisp_IZatGDzpfo3ffF57.yml
+++ b/src/packs/monsters/Will_O__Wisp_IZatGDzpfo3ffF57.yml
@@ -1,0 +1,150 @@
+folder: null
+name: Will-O'-Wisp
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Glowing, flickering orbs that haunt swamps and bogs, luring travelers
+    with eerie lights. They guide them to reveal secrets that only they
+    understand.</p>
+  notes: ''
+  role: trickster
+  tier: tough
+  traits:
+    - Ethereal Form
+    - Swift & Elusive
+    - Understands Language
+  moves:
+    - Luring Light
+    - Flicker Vanish
+    - Bewilder
+  desires:
+    - value: to find out how far your curiosity will take you.
+      are: false
+    - value: for followers to actually reach its destination.
+      are: false
+  sensories:
+    colors:
+      - name: Haunted Green
+        color: '#a7c07f'
+      - name: Phantom Violet
+        color: '#83799e'
+      - name: Spectral Blue
+        color: '#6a7b8b'
+    sights: faint flickering, eerie shadows, shifting colors
+    sounds: faint whispers, low hum, far off footstep echoes
+    smells: fleeting yet familiar and nostalgic smells
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Secrets to reveal
+      instructions: ''
+      table:
+        - - Final resting place of a hero never mourned.
+          - Wooden mask marked with a lost clan's sigil.
+          - Secret names of the will-o'-wisps.
+          - Undying flame hidden in the swamp’s heart.
+          - Waterlogged diary with half-legible confessions.
+          - Still-beating heart buried within twisted roots.
+prototypeToken:
+  name: Will-O'-Wisp
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368464521
+  modifiedTime: 1750368464521
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: IZatGDzpfo3ffF57
+sort: 0
+_key: '!actors!IZatGDzpfo3ffF57'
+

--- a/src/packs/monsters/Wyvern_68CW02YQgDOBiHAF.yml
+++ b/src/packs/monsters/Wyvern_68CW02YQgDOBiHAF.yml
@@ -1,0 +1,148 @@
+folder: null
+name: Wyvern
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Fierce, winged reptiles with a venomous, barbed tail. They swoop from
+    unseen heights, securing their prey with swift, brutal strikes.</p>
+  notes: ''
+  role: predator
+  tier: tough
+  traits:
+    - Relentless Pursuer
+    - Hardened Scales
+  moves:
+    - Venomous Sting
+    - Diving Strike
+    - Snatch and Fly
+  desires:
+    - value: to teach its young the thrill of the hunt.
+      are: false
+    - value: to feel a bond with a creature outside its kin.
+      are: false
+  sensories:
+    colors:
+      - name: Dark Slate
+        color: '#2f4f4e'
+      - name: Bronzed Ember
+        color: '#b87332'
+      - name: Savage Green
+        color: '#566b30'
+    sights: darting between clouds, animals scurrying for cover
+    sounds: screech from impossibly high, whoosh of its dive
+    smells: smell of their far off nesting location
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Wyvern Masters
+      instructions: ''
+      table:
+        - - Gorrak, infamous sky pirate.
+          - Laraen, rogue mage bent on vengeance.
+          - Zurak, black-market smuggler of wyvern eggs.
+          - Tylara, a druid wielding the power of storms.
+          - Drazul, assassin for the highest bidder.
+          - Serdrak, mercenary lord of the skies.
+prototypeToken:
+  name: Wyvern
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368465511
+  modifiedTime: 1750368465511
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: 68CW02YQgDOBiHAF
+sort: 0
+_key: '!actors!68CW02YQgDOBiHAF'
+

--- a/src/packs/monsters/Yeti_NrOQau8yS7z6OF3m.yml
+++ b/src/packs/monsters/Yeti_NrOQau8yS7z6OF3m.yml
@@ -1,0 +1,149 @@
+folder: null
+name: Yeti
+type: monster
+img: icons/svg/mystery-man.svg
+system:
+  biography: >-
+    <p>Massive, furry beasts roaming between icy peaks, fiercely guarding the
+    remote passes as if bound to the land by some unseen force.</p>
+  notes: ''
+  role: brute
+  tier: tough
+  traits:
+    - Frigid Aura
+    - Snowy Camouflage
+    - Speech (Roars, Gestures)
+  moves:
+    - Frost Breath
+    - Howling Roar
+    - Icicle Throw
+  desires:
+    - value: to maintain its lonesome vigil, instinctually.
+      are: false
+    - value: for the terrible secrets below to see light.
+      are: false
+  sensories:
+    colors:
+      - name: Frostbite Gray
+        color: '#b0b0b0'
+      - name: Glacial White
+        color: '#e0e9f0'
+      - name: Icy Blue
+        color: '#9ac0cd'
+    sights: the snow moving, steaming breath, pale blue eyes
+    sounds: crunch of snow under massive feet, deep roars
+    smells: fresh snow cut by a wild tang
+  pool:
+    diceNum: 0
+    max: null
+  tables:
+    - name: Under the Ice
+      instructions: ''
+      table:
+        - - City frozen in time, its bells still ringing.
+          - Souls wandering, lost beneath the ice.
+          - Portal to a realm of eternal winter.
+          - Cursed blade locked in unmelting ice.
+          - Phoenix stuck in a cycle of death and rebirth.
+          - Balor shackled in ice-forged chains.
+prototypeToken:
+  name: Yeti
+  displayName: 0
+  actorLink: false
+  appendNumber: false
+  prependAdjective: false
+  width: 1
+  height: 1
+  texture:
+    src: icons/svg/mystery-man.svg
+    anchorX: 0.5
+    anchorY: 0.5
+    offsetX: 0
+    offsetY: 0
+    fit: contain
+    scaleX: 1
+    scaleY: 1
+    rotation: 0
+    tint: '#ffffff'
+    alphaThreshold: 0.75
+  lockRotation: false
+  rotation: 0
+  alpha: 1
+  disposition: -1
+  displayBars: 0
+  bar1:
+    attribute: health
+  bar2:
+    attribute: power
+  light:
+    negative: false
+    priority: 0
+    alpha: 0.5
+    angle: 360
+    bright: 0
+    color: null
+    coloration: 1
+    dim: 0
+    attenuation: 0.5
+    luminosity: 0.5
+    saturation: 0
+    contrast: 0
+    shadows: 0
+    animation:
+      type: null
+      speed: 5
+      intensity: 5
+      reverse: false
+    darkness:
+      min: 0
+      max: 1
+  sight:
+    enabled: false
+    range: 0
+    angle: 360
+    visionMode: basic
+    color: null
+    attenuation: 0.1
+    brightness: 0
+    saturation: 0
+    contrast: 0
+  detectionModes: []
+  occludable:
+    radius: 0
+  ring:
+    enabled: false
+    colors:
+      ring: null
+      background: null
+    effects: 1
+    subject:
+      scale: 1
+      texture: null
+  flags: {}
+  randomImg: false
+  turnMarker:
+    mode: 1
+    animation: null
+    src: null
+    disposition: false
+  movementAction: null
+items: []
+effects: []
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  exportSource: null
+  coreVersion: '13.345'
+  systemId: grimwild
+  systemVersion: 0.1.7
+  createdTime: 1750368466546
+  modifiedTime: 1750368466546
+  lastModifiedBy: jgipq2YBy9KMjQWt
+ownership:
+  default: 0
+  jgipq2YBy9KMjQWt: 3
+_id: NrOQau8yS7z6OF3m
+sort: 0
+_key: '!actors!NrOQau8yS7z6OF3m'
+

--- a/src/system.yml
+++ b/src/system.yml
@@ -91,6 +91,14 @@ packs:
     ownership:
       PLAYER: LIMITED
       ASSISTANT: OWNER
+  - name: monsters
+    label: Monsters
+    type: Actor
+    path: packs/monsters
+    system: grimwild
+    ownership:
+      PLAYER: OBSERVER
+      ASSISTANT: OWNER
   - name: macros
     label: Grimwild Macros
     type: Macro


### PR DESCRIPTION
This commit adds a new system compendium with all the monsters from Chapter 5 of the rulebook. Credit for this incredible work goes to One Proud Bavarian (oneproudbavarian) from the Oddity Press discord server who took the time to do the data entry for all the monsters. I simply did the work of converting it into a system compendium.

Notes from oneproudbavarian:
* I left all the monsters on the automatically used tier "Tough" as Chapter 5 doesn't firmly assign anything to them and this is up to the GMs.
* I included a dragon actor that includes all Breath types and then individual Dragon actor in the "Dragon,[Type]" format that only include one specific breath type. I did a similar thing for Ettin - there is an Ettin actor with all the Ettin heads inside of the sheet and then three Ettin actors in the format "Ettin,[Head 1] & [Head 2]" that match the addigned PDF heads.
* I included any linked challenges present in Chapter 5, which means the Giants for example have their, but the Great Red Dragon example linked challenge is not included.
* The big weakness currently definitely rests with linked challenges... I think most linked challenges are legible for anybody that looks at them for the first time (Demon, Balor and Hydra for example should intuitively make sense), but the Ettercap for example is incredibly complex and isn't really interpretable for GMs without the numerous connections being displayed.