### PR TITLE
Release 0.2.0

### DIFF
--- a/release-notes/0.2.0.md
+++ b/release-notes/0.2.0.md
@@ -1,0 +1,47 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/grimwild/0.2.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v13.345](https://img.shields.io/badge/Foundry-v13.345-green)
+
+NOTE: This version of the system is only compatible with Foundry v13. Depending on available time, we may make an additional release in the next week or so to backport some of the features (bloodied, rattled, dropped, monsters) as a closing release for the v12 version of the system. The combat tracker however will NOT be backported, as that uses new APIs that are only available in v13+.
+
+## Changes
+
+- Adds support for Foundry v13, removes support for Foundry v12
+- Added monsters compendium (see section below for details, @gbrowdy and oneproudbavarian)
+- v1.4 rules changes:
+  - Marks can stack with bloodied and rattled
+  - Dice pools were removed from bloodied and rattled
+  - New checkboxes for bloodied, rattled, and dropped were added (@teroparvinen)
+  - Updated journal entries related to v1.4 rules changes (damage, treatment, path talents)
+- Added new setting to enable dice pools for both bloodied and rattled. The intent here is as a homebrew option to restore the v1.3 bloodied/rattled behavior.
+- Updated spark to have more straightforward logic on the checkboxes, similar to how XP currently works. (@teroparvinen)
+- Redesigned the combat tracker to include the following:
+  - Group characters and monsters separately
+  - Reflow initiative values when combatants are added to the combat track in increments of 10. This will later be expanded to allow for drag/drop reordering of combatants. For now, combatant initiatives are effectively just in the order they were added to the combat tracker.
+  - Added icons for Spark, Bloodied, and Rattled to characters in the combat tracker. Clicking this will toggle them on that actor if the user has permission, or in the case of spark will cycle it between 0, 1, and 2.
+  - Added an indicator for how many actions a character has taken in each combat. The intent here is for GMs to be able to eyeball who needs the spotlight the most.
+  - When an action is rolled, the current turn will be set to that character.
+- Various styling and bug fixes
+- Various lint warning and error fixes
+
+## Monsters Compendium
+
+The monsters compendium was created by One Proud Bavarian from the Grimwild discord, and converted to the system by @gbrowdy. Special thanks to One Proud Bavarian for this incredible +1d to the system!
+
+Some notes about it:
+- Monsters are configured to use the `Tough` tier by default.
+- There is both a general dragon actor and "Dragon, [Type]" actors that include only a specific breath type. Ettins are similar, based on their heads.
+- Linked challenges are included, but challenges in other chapters (e.g. the Great Red Dragon) were not included.
+- A major weakness with the system currently is the lack of any sort of visual representation of the links between challenges. This isn't something that will be simple to fix, but we'll consider our options for this in the future. Complex challenges like the Ettercap tend to be the worst offenders on this currently.
+
+## Changelog
+
+https://github.com/asacolips-projects/grimwild/compare/0.1.7...0.2.0
+
+## Contributors
+
+@asacolips, @teroparvinen, @gbrowdy, oneproudbavarian

--- a/src/styles/components/_dice.scss
+++ b/src/styles/components/_dice.scss
@@ -5,7 +5,9 @@ h2 {
 
 &.crit h2,
 &.perfect h2 {
-	color: #00bd00;
+	body.theme-dark & {
+		color: #00bd00;
+	}
 
 	body.theme-light & {
 		color: #007a00;
@@ -13,7 +15,9 @@ h2 {
 }
 
 &.messy h2 {
-	color: #ffd400;
+	body.theme-dark & {
+		color: #ffd400;
+	}
 
 	body.theme-light & {
 		color: #d68c03;
@@ -21,7 +25,9 @@ h2 {
 }
 
 &.grim h2 {
-	color: #999;
+	body.theme-dark & {
+		color: #999;
+	}
 
 	body.theme-light & {
 		color: #555;
@@ -29,7 +35,9 @@ h2 {
 }
 
 &.disaster h2 {
-	color: #ff5c37;
+	body.theme-dark & {
+		color: #ff5c37;
+	}
 
 	body.theme-light & {
 		color: #9c1e01;


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/grimwild/0.2.0/system.json

## Compatible Foundry versions

![Foundry v13.345](https://img.shields.io/badge/Foundry-v13.345-green)

NOTE: This version of the system is only compatible with Foundry v13. Depending on available time, we may make an additional release in the next week or so to backport some of the features (bloodied, rattled, dropped, monsters) as a closing release for the v12 version of the system. The combat tracker however will NOT be backported, as that uses new APIs that are only available in v13+.

## Changes

- Adds support for Foundry v13, removes support for Foundry v12
- Added monsters compendium (see section below for details, gbrowdy and oneproudbavarian)
- v1.4 rules changes:
  - Marks can stack with bloodied and rattled
  - Dice pools were removed from bloodied and rattled
  - New checkboxes for bloodied, rattled, and dropped were added (teroparvinen)
  - Updated journal entries related to v1.4 rules changes (damage, treatment, path talents)
- Added new setting to enable dice pools for both bloodied and rattled. The intent here is as a homebrew option to restore the v1.3 bloodied/rattled behavior.
- Updated spark to have more straightforward logic on the checkboxes, similar to how XP currently works. (@teroparvinen)
- Redesigned the combat tracker to include the following:
  - Group characters and monsters separately
  - Reflow initiative values when combatants are added to the combat track in increments of 10. This will later be expanded to allow for drag/drop reordering of combatants. For now, combatant initiatives are effectively just in the order they were added to the combat tracker.
  - Added icons for Spark, Bloodied, and Rattled to characters in the combat tracker. Clicking this will toggle them on that actor if the user has permission, or in the case of spark will cycle it between 0, 1, and 2.
  - Added an indicator for how many actions a character has taken in each combat. The intent here is for GMs to be able to eyeball who needs the spotlight the most.
  - When an action is rolled, the current turn will be set to that character.
- Various styling and bug fixes
- Various lint warning and error fixes

## Monsters Compendium

The monsters compendium was created by One Proud Bavarian from the Grimwild discord, and converted to the system by gbrowdy. Special thanks to One Proud Bavarian for this incredible +1d to the system!

Some notes about it:
- Monsters are configured to use the `Tough` tier by default.
- There is both a general dragon actor and "Dragon, [Type]" actors that include only a specific breath type. Ettins are similar, based on their heads.
- Linked challenges are included, but challenges in other chapters (e.g. the Great Red Dragon) were not included.
- A major weakness with the system currently is the lack of any sort of visual representation of the links between challenges. This isn't something that will be simple to fix, but we'll consider our options for this in the future. Complex challenges like the Ettercap tend to be the worst offenders on this currently.

## Changelog

https://github.com/asacolips-projects/grimwild/compare/0.1.7...0.2.0

## Contributors

asacolips, teroparvinen, gbrowdy, oneproudbavarian