### PR TITLE
Combat tracker enhancements

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -231,6 +231,8 @@ GRIMWILD:
     Roll: Roll
   Combat:
     ActionCount: 'Rolls'
+    ResetActionCount: Reset Action Count
+    SpotlightActor: Spotlight
 TYPES:
   Actor:
     character: Character

--- a/src/module/apps/token-hud.mjs
+++ b/src/module/apps/token-hud.mjs
@@ -1,0 +1,22 @@
+
+export class GrimwildTokenHud extends foundry.applications.hud.TokenHUD {
+	static DEFAULT_OPTIONS = {
+		...super.DEFAULT_OPTIONS,
+		actions: {
+			spotlight: GrimwildTokenHud.#onSpotlight
+		}
+	};
+
+	static PARTS = {
+		hud: {
+			root: true,
+			template: "systems/grimwild/templates/hud/token-hud.hbs"
+		}
+	};
+
+	static #onSpotlight(event, target) {
+		const combatant = game.combats.viewed?.turns.find((c) => c.tokenId === this.object.id);
+		game.combats.viewed?.spotlightCombatant(combatant?.id);
+		this.close();
+	}
+}

--- a/src/module/grimwild.mjs
+++ b/src/module/grimwild.mjs
@@ -17,6 +17,7 @@ import * as utils from "./helpers/utils.js";
 import * as models from "./data/_module.mjs";
 
 import { SUSPENSE_TRACKER } from "./controls/suspense.mjs";
+import { GrimwildTokenHud } from "./apps/token-hud.mjs";
 
 /* -------------------------------------------- */
 /*  Init Hook                                   */
@@ -90,6 +91,8 @@ Hooks.once("init", function () {
 	// Override combat classes.
 	CONFIG.Combat.documentClass = grimwild.documents.GrimwildCombat;
 	CONFIG.ui.combat = grimwild.applications.GrimwildCombatTracker;
+
+	CONFIG.Token.hudClass = GrimwildTokenHud;
 
 	// Register sheet application classes
 	foundry.documents.collections.Actors.unregisterSheet("core", foundry.appv1.sheets.ActorSheet);

--- a/src/styles/components/_combat.scss
+++ b/src/styles/components/_combat.scss
@@ -53,3 +53,11 @@
     text-align: center;
   }
 }
+
+.encounter-context-menu {
+  margin-left: auto;
+}
+
+.combat-tracker .combatant-controls {
+  gap: 0;
+}

--- a/src/templates/combat/header.hbs
+++ b/src/templates/combat/header.hbs
@@ -1,0 +1,54 @@
+<header class="combat-tracker-header">
+
+    {{!-- Encounter Controls --}}
+    {{#if user.isGM}}
+    <nav class="encounters {{ css }}" aria-label="{{ localize "COMBAT.NavLabel" }}">
+
+        {{!-- Cycle Display --}}
+        {{#if displayCycle}}
+        <button type="button" class="inline-control icon fa-solid fa-plus" data-action="createCombat"
+                data-tooltip aria-label="{{ localize "COMBAT.Create" }}"></button>
+
+        <div class="cycle-combats">
+            <button type="button" class="inline-control icon fa-solid fa-caret-left" data-action="cycleCombat"
+                    {{#if previousId}}data-combat-id="{{ previousId }}" {{else}}disabled{{/if}}
+                    data-tooltip aria-label="{{ localize "COMBAT.EncounterPrevious" }}"></button>
+            <div class="encounter-count">
+                <span class="value">{{ currentIndex }}</span>
+                <span class="separator">&sol;</span>
+                <span class="max">{{ combats.length }}</span>
+            </div>
+            <button type="button" class="inline-control icon fa-solid fa-caret-right" data-action="cycleCombat"
+                    {{#if nextId}}data-combat-id="{{ nextId }}" {{else}}disabled{{/if}}
+                    data-tooltip aria-label="{{ localize "COMBAT.EncounterNext" }}"></button>
+        </div>
+
+        <button type="button" class="encounter-context-menu inline-control combat-control icon fa-solid fa-ellipsis-vertical"
+                {{#unless (and user.isGM hasCombat)}}disabled{{/unless}}></button>
+
+        {{!-- Tabbed Display --}}
+        {{else if combats.length}}
+        <button type="button" class="inline-control icon fa-solid fa-plus" data-action="createCombat"
+                data-tooltip aria-label="{{ localize "COMBAT.Create" }}"></button>
+        {{#each combats}}
+        <button type="button" class="inline-control {{#if active}}active{{/if}}" data-action="cycleCombat"
+                data-combat-id="{{ id }}">
+            {{ label }}
+        </button>
+        {{/each}}
+
+        <button type="button" class="encounter-context-menu inline-control combat-control icon fa-solid fa-ellipsis-vertical"
+                {{#unless (and user.isGM hasCombat)}}disabled{{/unless}}></button>
+
+        {{!-- No Combats --}}
+        {{else}}
+        <button type="button" class="combat-control-lg" data-action="createCombat">
+            <i class="fa-solid fa-plus" inert></i>
+            <span>{{ localize "COMBAT.Create" }}</span>
+        </button>
+
+        {{/if}}
+    </nav>
+    {{/if}}
+
+</header>

--- a/src/templates/combat/tracker.hbs
+++ b/src/templates/combat/tracker.hbs
@@ -20,6 +20,8 @@
 					<strong class="name">{{ name }}</strong>
 					<div class="combatant-controls">
 						{{#if @root.user.isGM}}
+						<button type="button" class="inline-control combatant-control icon fa-solid fa-arrows-to-dot"
+								data-action="spotlight" data-tooltip aria-label="{{ localize "GRIMWILD.Combat.SpotlightActor" }}"></button>
 						<button type="button" class="inline-control combatant-control icon fa-solid fa-eye-slash {{#if hidden}}active{{/if}}"
 								data-action="toggleHidden" data-tooltip aria-label="{{ localize "COMBAT.ToggleVis" }}"></button>
 						<button type="button" class="inline-control combatant-control icon fa-solid fa-skull {{#if isDefeated}}active{{/if}}"

--- a/src/templates/hud/token-hud.hbs
+++ b/src/templates/hud/token-hud.hbs
@@ -1,0 +1,56 @@
+<div class="col left">
+    <div class="attribute elevation" data-tooltip="HUD.Elevation">
+        <i class="fas fa-angle-up"></i>
+        <input type="text" name="elevation" value="{{elevation}}" {{disabled (or locked (and isGamePaused (not isGM)))}}>
+    </div>
+
+    <button type="button" class="control-icon" data-action="sort" data-direction="up" data-tooltip="HUD.ToFront">
+        <img src="{{icons.up}}">
+    </button>
+
+    <button type="button" class="control-icon" data-action="sort" data-direction="down" data-tooltip="HUD.ToBack">
+        <img src="{{icons.down}}">
+    </button>
+
+    {{#if canConfigure}}
+    <button type="button" class="control-icon" data-action="config" data-tooltip="HUD.OpenConfig">
+        <i class="fa-solid fa-gear" inert></i>
+    </button>
+    {{/if}}
+</div>
+
+<div class="col middle">
+    <div class="attribute bar2">
+        {{#if displayBar2}}
+        <input type="text" name="bar2" value="{{bar2Data.value}}" {{#unless bar2Data.editable}}disabled{{/unless}}>
+        {{/if}}
+    </div>
+
+    <div class="attribute bar1">
+        {{#if displayBar1}}
+        <input type="text" name="bar1" value="{{bar1Data.value}}" {{#unless bar1Data.editable}}disabled{{/unless}}>
+        {{/if}}
+    </div>
+</div>
+
+<div class="col right">
+    {{#if isGM}}
+    <button type="button" class="control-icon {{visibilityClass}}" data-action="visibility" data-tooltip="HUD.ToggleVis">
+        <img src="{{icons.visibility}}">
+    </button>
+    {{/if}}
+
+    <button type="button" class="control-icon {{targetClass}}" data-action="target" data-tooltip="HUD.ToggleTargetState">
+        <i class="fa-solid fa-bullseye" inert></i>
+    </button>
+
+    <button type="button" class="control-icon {{targetClass}}" data-action="spotlight" data-tooltip="GRIMWILD.Combat.SpotlightActor">
+        <i class="fa-solid fa-arrows-to-dot" inert></i>
+    </button>
+
+    {{#if canToggleCombat}}
+    <button type="button" class="control-icon {{combatClass}}" data-action="combat" data-tooltip="HUD.ToggleCombatState">
+        <img src="{{icons.combat}}">
+    </button>
+    {{/if}}
+</div>


### PR DESCRIPTION
On the combat tracker
- Remove the row with the round number and initiative rollers, since they are not needed with Grimwild
- Add options for resetting the action count, for the entire combat or for individual combatants (menu)
- Add a button to spotlight a combatant on the list, i.e. make them active in the turn order

For tokens
- Remove some redundant options from the token HUD
- Add a button for highlighting the token in the active combat directly from the token HUD