### PR TITLE
Release 0.5.3

### DIFF
--- a/release-notes/0.5.3.md
+++ b/release-notes/0.5.3.md
@@ -1,0 +1,20 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/grimwild/0.5.3/system.json
+
+## Compatible Foundry versions
+
+![Foundry v13.351](https://img.shields.io/badge/Foundry-v13.351-green)
+
+## Changes
+- Fixed bug with condition pools being unable to be rolled from the character sheet.
+- Updated color coding on die results to use a light blue color for 1s, making it easier to spot when a sorcerer should have a wild surge.
+- Added song composition table to the Bardsong talent's description
+
+## Changelog
+
+https://github.com/asacolips-projects/grimwild/compare/0.5.2...0.5.3
+
+## Contributors
+
+@asacolips

--- a/src/system.yml
+++ b/src/system.yml
@@ -1,7 +1,7 @@
 id: grimwild
 title: Grimwild
 description: The Grimwild system for FoundryVTT!
-version: '0.5.2'
+version: '0.5.3'
 compatibility:
   minimum: '13'
   verified: '13.351'


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/grimwild/0.5.3/system.json

## Compatible Foundry versions

![Foundry v13.351](https://img.shields.io/badge/Foundry-v13.351-green)

## Changes
- Fixed bug with condition pools being unable to be rolled from the character sheet.
- Updated color coding on die results to use a light blue color for 1s, making it easier to spot when a sorcerer should have a wild surge.
- Added song composition table to the Bardsong talent's description

## Changelog

https://github.com/asacolips-projects/grimwild/compare/0.5.2...0.5.3

## Contributors

@asacolips